### PR TITLE
feat(skills): add strategy-deep-research skill

### DIFF
--- a/.claude/commands/informe-ia-medicina.md
+++ b/.claude/commands/informe-ia-medicina.md
@@ -1,0 +1,56 @@
+---
+description: Genera el informe semanal "¿Cómo se está usando la IA en medicina?" (deep-research + HTML + PDF) y lo envía a WhatsApp por CallMeBot. Pensado para correr cada lunes (manual o programado).
+---
+
+# Informe semanal — IA en medicina
+
+Eres un agente de investigación. Hoy generas el informe semanal **"¿Cómo se está usando la inteligencia artificial en medicina?"** de forma autónoma, de punta a punta.
+
+## Paso 1 · Investigar (strategy-deep-research)
+
+Invoca la skill **`strategy-deep-research`** en **modo mixto (médico + web)** con esta pregunta:
+
+> Novedades de las **últimas 1-2 semanas** sobre aplicaciones reales de la inteligencia artificial en medicina: herramientas clínicas nuevas, estudios y ensayos publicados, aprobaciones o pronunciamientos regulatorios (FDA, EMA, OMS), IA en diagnóstico/imagen/oncología/atención primaria/administración clínica, y debates o riesgos relevantes.
+
+Reglas:
+- **Prioriza fuentes primarias/oficiales**: PubMed para estudios (filtra por fecha reciente), webs de FDA/EMA/OMS, papers, comunicados oficiales. Los blogs solo como pista hacia la fuente primaria.
+- Profundidad **estándar (2 rondas)**. Idioma **español**.
+- Caracteriza conflictos y marca lo no verificado.
+
+Output: `report.md` citado (Vancouver para lo científico, tabla web para lo demás) en:
+`projects/strategy-deep-research/<YYYY-MM-DD>-ia-medicina-semanal/`
+
+## Paso 2 · HTML (tool-visual-explainer)
+
+Invoca **`tool-visual-explainer`** para generar `report.html` en la misma carpeta, con la **plantilla de marca** (hero con degradado, secciones numeradas, footer "Generado por Dr. Juan Camilo Paris"). Estructura de secciones: Resumen ejecutivo (KPIs + bullets), Hallazgos por tema, Conflictos/confianza, Vacíos, Referencias.
+
+## Paso 3 · Publicar y entregar por WhatsApp
+
+**3a. Publicar** — ejecuta el script (genera PDF con Chrome, sube HTML + PDF a GitHub Pages `reportes-ia-medicina`, imprime los enlaces):
+
+```bash
+bash scripts/enviar-informe-whatsapp.sh "projects/strategy-deep-research/<YYYY-MM-DD>-ia-medicina-semanal/report.html"
+```
+
+El script imprime `PUBLISHED_HTML=...` y (si Chrome estaba disponible) `PUBLISHED_PDF=...`. Si no hay PDF, sigue solo con el enlace web.
+
+**3b. Enviar WhatsApp** — con los enlaces que imprimió el script, envía vía CallMeBot. Dentro de Claude Code `curl` está bloqueado, así que usa **WebFetch** a:
+
+```
+https://api.callmebot.com/whatsapp.php?phone=<CALLMEBOT_PHONE>&text=<mensaje-urlencoded>&apikey=<CALLMEBOT_APIKEY>
+```
+
+Credenciales en `.env.local` (`CALLMEBOT_PHONE`, `CALLMEBOT_APIKEY`). Mensaje sugerido (URL-encoded): título + "Leer en web: <PUBLISHED_HTML>" + "Descargar PDF: <PUBLISHED_PDF>".
+
+Fuera de Claude (Tarea Programada de Windows), el mismo envío se hace con `curl` al mismo endpoint.
+
+Si algo falla, NO inventes el envío: reporta el error y deja el HTML/PDF en la carpeta para envío manual.
+
+## Paso 4 · Cierre
+
+Termina con un **resumen de 3 líneas** de lo más relevante de la semana, y la ruta de los archivos generados.
+
+## Notas para corridas automáticas (headless)
+
+- Si el MCP de PubMed o las herramientas web NO están disponibles en la corrida programada, haz lo que puedas con lo disponible, **dilo explícitamente** en el informe y no inventes fuentes.
+- No publiques datos de pacientes ni información sensible: este informe usa solo literatura y fuentes públicas.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,8 @@
       "Bash(find *)",
       "Bash(mkdir *)",
       "Bash(cp *)",
-      "Bash(mv *)"
+      "Bash(mv *)",
+      "WebFetch(domain:api.callmebot.com)"
     ],
     "deny": [
       "Bash(rm -rf *)",

--- a/.claude/skills/strategy/strategy-deep-research/SKILL.md
+++ b/.claude/skills/strategy/strategy-deep-research/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: strategy-deep-research
+description: Investigación profunda multironda con disciplina de fuentes primarias y citas verificables. Se comporta como un agente de deep research: planifica, delega subagentes en paralelo, prioriza fuentes oficiales/primarias sobre blogs, itera hasta saturar el tema, y entrega un reporte Markdown + HTML con cada afirmación citada (URL + fecha + tier de confianza). Para temas biomédicos usa el MCP de PubMed como fuente primaria y el proxy universitario para artículos de pago. Úsala cuando el usuario diga "investiga a fondo", "deep research", "investigación profunda", "qué dice la evidencia sobre", "revisión de literatura", o pida un informe documentado con referencias.
+---
+
+# strategy-deep-research
+
+Agente de investigación profunda. No es una búsqueda rápida: es un proceso iterativo que prioriza fuentes primarias/oficiales, descarta blogs sin actualización como evidencia, y **nunca afirma nada sin citar de dónde salió**.
+
+## Cuándo se invoca
+
+- Usuario: "investiga a fondo X", "deep research sobre Y", "investigación profunda", "revisión de literatura", "qué dice la evidencia sobre Z", "hazme un informe documentado de…"
+- Cuando una decisión (clínica, de negocio, técnica) necesita respaldo con fuentes verificables, no opinión.
+- **NO** para lookups rápidos de un dato único → eso es `strategy-web-research`. Esta skill es la versión pesada: úsala cuando la profundidad y la trazabilidad importan más que la velocidad.
+
+## Principios no negociables
+
+1. **Prioridad de fuente primaria.** Toda afirmación se respalda con la fuente más cercana al origen posible. Clasifica cada fuente por tier (ver `references/source-tiers.md`). Solo **Tier 0–1** cuentan como evidencia citable. Tier 2–3 (blogs, agregadores, foros) sirven como *pistas* para encontrar la fuente primaria, nunca como autoridad.
+2. **Recencia explícita.** Cada fuente lleva fecha de publicación y de último update conocido. Marca como ⚠️ cualquier fuente cuya antigüedad importe para el tema (guías clínicas >5 años, datos de mercado >18 meses, docs técnicas de una versión obsoleta).
+3. **Cero afirmación sin cita.** Cada frase con contenido factual lleva `[n]` inline. Si no hay fuente, se dice explícitamente "sin fuente verificable" y se trata como hipótesis, no como hecho.
+4. **Conflictos a la vista.** Si dos fuentes Tier 0–1 se contradicen, se reportan ambas con su cita y se da un nivel de confianza. No se esconde la discrepancia eligiendo una.
+5. **Trazabilidad.** El reporte permite a cualquiera reconstruir la búsqueda: query usada, fecha de acceso, tier, URL/DOI.
+
+## Process
+
+### Paso 0 · Clasificar el dominio y elegir el carril
+
+Antes de buscar, decide:
+
+- **¿Tema biomédico/clínico/ciencias de la vida?** (oncología, fármacos, fisiología, epidemiología, genética…) → **modo médico**: PubMed MCP es la fuente primaria. Lee `references/medical-sources.md`.
+- **¿Tema general / negocio / técnico / regulatorio?** → **modo web**: WebSearch + WebFetch + Firecrawl, con foco en fuentes oficiales (`.gov`, `.edu`, organismos, papers, docs oficiales del fabricante, normativa).
+- **¿Mixto?** Corre ambos carriles en paralelo.
+
+Detecta también el **idioma de salida** (español por defecto) y la **profundidad pedida** (rápida 1 ronda / estándar 2 / exhaustiva 3+).
+
+### Paso 1 · Plan de investigación (escrito)
+
+1. Crea la carpeta de trabajo:
+   ```
+   projects/strategy-deep-research/<YYYY-MM-DD>-<tema-corto>/
+   ```
+2. Escribe `research-plan.md` con:
+   - **Pregunta principal** (reformulada con precisión, sin acrónimos ambiguos)
+   - **2–5 subpreguntas** ortogonales (sin solapamiento)
+   - **Fuentes esperadas por subpregunta** (qué tier y qué tipo: paper, guía clínica, normativa, doc oficial)
+   - **Criterio de parada** (cuándo consideramos el tema saturado)
+
+**Guía de alcance:**
+- Fact-finding documentado: 1–2 subpreguntas
+- Comparativa: 1 subpregunta por elemento (máx 3)
+- Revisión profunda: 3–5 subpreguntas
+
+### Paso 2 · Ronda 1 — búsqueda amplia con subagentes en paralelo
+
+Por cada subpregunta, lanza un subagente (`Agent`, subagent_type `general-purpose`) **en paralelo (máx 3 a la vez)**. Cada subagente:
+
+- Recibe la subpregunta concreta + el **tier mínimo aceptable** + instrucción de priorizar fuentes oficiales.
+- Tiene presupuesto: 4–6 búsquedas.
+- En **modo médico**, usa las tools `mcp__58c80515-…__search_articles` / `get_article_metadata` / `get_full_text_article` en vez de (o además de) WebSearch.
+- **Escribe sus hallazgos a archivo**, no los devuelve en prosa: `findings-<subpregunta>.md` con, por cada hallazgo: afirmación, cita literal corta, URL/DOI, fecha pub, tier estimado.
+
+Plantilla de instrucción al subagente → `references/subagent-brief.md`.
+
+### Paso 3 · Análisis de vacíos (gap analysis)
+
+Lee todos los `findings-*.md`. Construye un mapa:
+
+- Qué subpreguntas quedaron bien cubiertas con Tier 0–1.
+- Qué quedó solo con Tier 2–3 (necesita rastrear la fuente primaria).
+- Qué afirmaciones se contradicen entre fuentes.
+- Qué quedó sin responder.
+
+Si todo está cubierto con Tier 0–1 y sin conflictos abiertos → salta a Paso 5. Si no → Paso 4.
+
+### Paso 4 · Rondas de profundización (el "deep")
+
+Lanza búsquedas **dirigidas** (no amplias) solo sobre los huecos:
+
+- Rastrear la fuente primaria detrás de una pista Tier 2–3 (p. ej. el blog cita un estudio → ir al estudio).
+- Resolver conflictos buscando una fuente Tier 0 que arbitre (meta-análisis, guía oficial, normativa vigente).
+- **Modo médico**: usa `find_related_articles` para snowballing y `get_full_text_article` para leer métodos/resultados; para artículos de pago, activa la **vía proxy universitario** (`references/medical-sources.md`).
+
+Repite Paso 3 ↔ 4 hasta cumplir el criterio de parada o tope de rondas. **No sobre-investigues**: si dos rondas no mueven la aguja, para y reporta el vacío.
+
+### Paso 5 · Síntesis citada
+
+Escribe `report.md` siguiendo la plantilla de `references/citation-format.md`:
+
+1. **Resumen ejecutivo** (5–8 bullets, cada uno con su `[n]`)
+2. **Hallazgos por subpregunta**, prosa con citas inline `[n]`
+3. **Conflictos y nivel de confianza** (tabla: afirmación · fuentes a favor · en contra · confianza Alta/Media/Baja)
+4. **Vacíos / lo que no se pudo verificar**
+5. **Abreviaturas / glosario (obligatorio en modo médico/científico)** — coloca un bloque "Abreviaturas" justo después de los metadatos del reporte, antes del resumen ejecutivo, con cada sigla y su término completo. Además, **expande toda sigla en su primera aparición en el texto**: término completo seguido de la sigla entre paréntesis (p. ej. "ensayo clínico aleatorizado (ECA)", "supervivencia global (OS)"), y a partir de ahí usa la sigla. Esto vale tanto para `report.md` como para `report.html`. Objetivo: que el operador y cualquiera con quien comparta el documento entiendan cada término sin conocimiento previo.
+6. **Referencias** — el estilo depende del carril (ver `references/citation-format.md`):
+   - **Modo médico/científico → estilo Vancouver**: lista numerada por orden de aparición (`Autores. Título. Abrev journal. Año;Vol(Núm):págs. doi. PMID.`), hasta 6 autores + `et al.`
+   - **Modo web/general → tabla web**: título · sitio/organismo · tier · URL · fecha publicación · fecha de acceso (para abrir y verificar cada página).
+   - **Modo mixto**: Vancouver para las científicas + tabla web para el resto, en dos bloques.
+7. En modo médico, **atribución obligatoria a PubMed + DOIs** (lo exige la licencia del MCP).
+
+### Paso 6 · Gate de calidad
+
+Invoca `tool-output-verifier` sobre `report.md`. Debe pasar:
+- ¿Toda afirmación factual tiene `[n]`?
+- ¿Toda `[n]` resuelve a una entrada de la lista/tabla de referencias?
+- ¿Hay alguna fuente Tier 2–3 citada como evidencia? (debe ser 0)
+- **¿El estilo de referencia coincide con el carril?** Médico/científico → Vancouver bien formado (autores, journal abreviado, año, vol, DOI/PMID); web/general → cada entrada tiene URL abrible + fecha de acceso.
+- ¿Cada referencia tiene fecha y URL/DOI?
+- **(Modo médico) ¿Hay bloque de abreviaturas y toda sigla se expande en su primera aparición?** Si aparece una sigla sin definir (CPS, OS, PFS, HR, ECA, EA, MSI, ITT, etc.), corrige antes de entregar.
+
+Si falla, vuelve al paso correspondiente. No entregues un reporte que no pase el gate.
+
+### Paso 7 · HTML visual compartible
+
+Invoca `tool-visual-explainer` para generar `report.html` autocontenido a partir de `report.md`: resumen, hallazgos, tabla de referencias clicable, y un badge de tier por fuente. Es el entregable que se comparte.
+
+### Paso 8 · Cierre y aprendizaje
+
+- Append en `context/learnings.md` bajo `## strategy-deep-research`: fecha + qué fuentes/queries funcionaron mejor para este tipo de tema, qué proxy/journal dio problemas.
+- Si el tema reaparece, propón guardarlo como nota en el segundo cerebro (ver memoria del operador).
+- Propón commit del reporte si vive dentro del repo.
+
+## Outputs
+
+```
+projects/strategy-deep-research/<YYYY-MM-DD>-<tema>/
+├── research-plan.md
+├── findings-<subpregunta>.md   (uno por subagente)
+├── report.md                   # entregable principal, citado
+└── report.html                 # versión visual compartible
+```
+
+## Skills / tools que llama
+
+- **Subagentes `Agent` (general-purpose)** — búsqueda paralela por subpregunta.
+- **MCP PubMed** (`mcp__58c80515-b371-45ea-be47-178343711676__*`) — fuente primaria en modo médico.
+- **Claude in Chrome** (`mcp__Claude_in_Chrome__*`) — recuperar texto completo de artículos de pago vía proxy universitario (sesión autenticada por el usuario).
+- **`tool-firecrawl-scraper`** — extraer contenido limpio de webs oficiales con bot-blockers.
+- **WebSearch / WebFetch** — búsqueda y fetch general (modo web).
+- **`tool-output-verifier`** — gate de citas antes de entregar.
+- **`tool-visual-explainer`** — HTML compartible.
+- **`strategy-web-research`** — NO la llama; es su hermana ligera. Si el usuario solo quiere un dato rápido, deriva a esa.
+
+## Edge cases
+
+- **Sin acceso a internet / tools de web fallan**: reporta qué se pudo y qué no; no inventes fuentes.
+- **Artículo de pago sin proxy configurado**: usa abstract de PubMed + marca el hallazgo como "texto completo no verificado", y ofrece la URL proxificada para que el usuario lo abra.
+- **Tema fuera de PubMed** (física, CS, derecho): PubMed no aplica; usa modo web con fuentes oficiales del dominio (arXiv, BOE/normativa, docs oficiales).
+- **Solo hay blogs sobre el tema**: dilo explícitamente — "no encontré fuentes primarias; lo disponible es Tier 2–3" — y no eleves un blog a evidencia.
+- **El usuario pide velocidad**: ofrece bajar a 1 ronda, pero mantén la disciplina de citas.
+
+## Examples
+
+Ver `references/examples.md`.

--- a/.claude/skills/strategy/strategy-deep-research/SKILL.md
+++ b/.claude/skills/strategy/strategy-deep-research/SKILL.md
@@ -111,7 +111,16 @@ Si falla, vuelve al paso correspondiente. No entregues un reporte que no pase el
 
 ### Paso 7 · HTML visual compartible
 
-Invoca `tool-visual-explainer` para generar `report.html` autocontenido a partir de `report.md`: resumen, hallazgos, tabla de referencias clicable, y un badge de tier por fuente. Es el entregable que se comparte.
+Invoca `tool-visual-explainer` para generar `report.html` autocontenido a partir de `report.md`, usando su **plantilla fija de marca** (hero con degradado + secciones numeradas). Mapea siempre las secciones en este orden y con estos componentes para que todos los reportes tengan la misma forma:
+
+1. **Abreviaturas** → componente `chips` (sigla en pastilla + término).
+2. **Resumen ejecutivo** → `kpi` (cifras clave) + `list` (bullets citados).
+3. **Hallazgos / gradiente** → `table` (en `tablewrap`).
+4. **Conflictos y confianza** → `table` + `badge` (`b-hi`/`b-med`/`b-lo` = Alta/Media/Baja) + `callout` para la lectura clínica.
+5. **Vacíos / no verificado** → bloque `gap`.
+6. **Referencias** → `refs` (lista numerada con DOI/PMID enlazados).
+
+Footer fijo: "Generado por Dr. Juan Camilo Paris". Es el entregable que se comparte.
 
 ### Paso 8 · Cierre y aprendizaje
 

--- a/.claude/skills/strategy/strategy-deep-research/references/citation-format.md
+++ b/.claude/skills/strategy/strategy-deep-research/references/citation-format.md
@@ -1,0 +1,130 @@
+# Disciplina de citas y plantilla de reporte
+
+## Reglas de citado
+
+1. **Inline numérico**: cada afirmación factual termina con `[n]`. Varias fuentes para una afirmación: `[1][3]`. (Vancouver también usa numeración por orden de aparición → encaja directo.)
+2. **Una `[n]` = una entrada** en la lista de referencias. Sin huérfanas en ninguna dirección.
+3. **Cita literal corta** cuando la redacción exacta importa (cifras, definiciones legales, dosis): usa comillas + `[n]`.
+4. **Fecha de acceso obligatoria** para fuentes web (cambian). Para papers, basta DOI/PMID + fecha de publicación.
+5. **Nunca parafrasear cambiando el sentido**. Si la fuente dice "puede reducir", no escribas "reduce".
+
+## Abreviaturas (obligatorio en modo médico/científico)
+
+En redacción científica, toda sigla se presenta **primero con su término completo** y la sigla entre paréntesis; después se usa la sigla. Además se incluye un **bloque "Abreviaturas"** al inicio del reporte (tras los metadatos, antes del resumen ejecutivo) para que cualquier lector lo entienda sin contexto previo.
+
+Reglas:
+1. Primera aparición en el texto: `término completo (SIGLA)` — p. ej. "supervivencia global (OS)", "ensayo clínico aleatorizado (ECA)".
+2. Bloque "Abreviaturas" en formato lista o tabla `SIGLA — término completo`.
+3. En el HTML, el mismo bloque va visible cerca del encabezado (no escondido).
+
+Lista base frecuente en oncología (adáptala al tema; expande solo las que uses):
+
+| Sigla | Término completo |
+|---|---|
+| OS | supervivencia global (overall survival) |
+| PFS | supervivencia libre de progresión (progression-free survival) |
+| HR | hazard ratio (razón de riesgos instantáneos) |
+| IC95% | intervalo de confianza del 95% |
+| ECA | ensayo clínico aleatorizado |
+| EA | eventos adversos |
+| ORR | tasa de respuesta objetiva (objective response rate) |
+| CPS | puntuación positiva combinada de PD-L1 (combined positive score) |
+| PD-1 | proteína de muerte celular programada 1 |
+| PD-L1 | ligando 1 de muerte celular programada |
+| MSI | inestabilidad de microsatélites (microsatellite instability); MSI-alto = MSI-high |
+| ITT | intención de tratar (intention-to-treat) |
+| HER2 | receptor 2 del factor de crecimiento epidérmico humano |
+| UGE | unión gastroesofágica |
+
+> Nota: HR (hazard ratio) NO es lo mismo que OR (odds ratio) ni RR (riesgo relativo). Usa el que reporte la fuente; no los intercambies.
+
+## El estilo de referencia depende del carril
+
+- **Modo médico / científico → estilo Vancouver** (es el estándar biomédico). Lista numerada por orden de aparición, no tabla.
+- **Modo web / general → referencia web simple**: título · sitio/organismo · URL · fecha de acceso (+ tier). Tabla, para que sea fácil abrir y verificar cada página.
+- **Modo mixto**: usa Vancouver para las fuentes científicas y la tabla web para el resto, en dos bloques separados dentro de la misma sección "Referencias".
+
+### Formato Vancouver (modo médico/científico)
+
+Numeración por orden de aparición en el texto. Estructura de cada entrada:
+
+```
+n. Autores. Título del artículo. Abreviatura del journal. Año;Volumen(Número):páginas. doi:DOI. PMID: nnnn.
+```
+
+Reglas Vancouver clave:
+- **Autores**: apellido + iniciales sin puntos (`García-López MA`). Lista hasta **6 autores**; si hay 7+, los primeros 6 + `et al.`
+- **Journal**: abreviatura oficial NLM (p. ej. `N Engl J Med`, `Lancet Oncol`, `J Clin Oncol`). Si dudas de la abreviatura, usa el nombre completo antes que inventarla.
+- **Sin coma entre apellido e iniciales**; autores separados por coma; punto final tras la lista.
+- **DOI y PMID** al final cuando existan (vienen del MCP de PubMed).
+
+Ejemplos:
+
+```
+1. Janjigian YY, Shitara K, Moehler M, et al. First-line nivolumab plus chemotherapy versus chemotherapy alone for advanced gastric cancer (CheckMate 649). Lancet. 2021;398(10294):27-40. doi:10.1016/S0140-6736(21)00797-2. PMID: 34102137.
+2. World Health Organization. WHO classification of tumours: digestive system tumours. 5th ed. Lyon: IARC; 2019.
+```
+
+Para libros, guías de sociedad e informes oficiales, usa la variante Vancouver correspondiente (autor/organismo. Título. Edición. Lugar: Editorial; Año.).
+
+### Formato referencia web (modo general)
+
+Tabla, una fila por fuente, pensada para abrir y verificar:
+
+```
+| # | Título | Sitio / Organismo | Tier | URL | Publicado | Accedido |
+```
+
+## Plantilla de `report.md`
+
+```markdown
+# Investigación: <pregunta principal>
+
+> Fecha: <YYYY-MM-DD> · Profundidad: <rápida|estándar|exhaustiva> · Rondas: <n>
+> Carril: <médico|web|mixto>
+
+## Resumen ejecutivo
+- Hallazgo clave 1 [1]
+- Hallazgo clave 2 [2][5]
+- ...
+
+## Hallazgos
+
+### <Subpregunta 1>
+Prosa con citas inline [1]. Cuando hay cifras exactas, "cita literal" [2].
+
+### <Subpregunta 2>
+...
+
+## Conflictos y nivel de confianza
+
+| Afirmación | A favor | En contra | Confianza |
+|---|---|---|---|
+| <afirmación> | [1][4] | [7] | Media |
+
+## Vacíos / no verificado
+- <qué quedó sin fuente primaria y por qué>
+
+## Referencias
+
+<!-- MODO MÉDICO/CIENTÍFICO → lista numerada estilo Vancouver: -->
+1. Janjigian YY, Shitara K, Moehler M, et al. First-line nivolumab plus chemotherapy versus chemotherapy alone for advanced gastric cancer. Lancet. 2021;398(10294):27-40. doi:10.1016/S0140-6736(21)00797-2. PMID: 34102137.
+2. …
+
+> Datos biomédicos vía **PubMed / PubMed Central** (NCBI). DOIs incluidos en cada referencia.
+
+<!-- MODO WEB/GENERAL → tabla web (sustituye la lista de arriba): -->
+| # | Título | Sitio / Organismo | Tier | URL | Publicado | Accedido |
+|---|---|---|---|---|---|---|
+| 1 | … | DIAN | 0 | https://… | 2026-01 | 2026-05-29 |
+
+<!-- MODO MIXTO → ambos bloques, científicas en Vancouver y resto en tabla web. -->
+```
+
+## Nivel de confianza — cómo asignarlo
+
+- **Alta**: ≥2 fuentes Tier 0–1 concordantes, recientes, sin conflicto de interés.
+- **Media**: 1 fuente Tier 0–1, o varias Tier 1 sin Tier 0, o ligera discrepancia.
+- **Baja**: solo Tier 2 rastreado a algo no confirmado, fuente única antigua, o conflicto abierto entre Tier 0.
+
+Una afirmación de confianza Baja **debe** decirlo en el cuerpo, no solo en la tabla.

--- a/.claude/skills/strategy/strategy-deep-research/references/examples.md
+++ b/.claude/skills/strategy/strategy-deep-research/references/examples.md
@@ -1,0 +1,35 @@
+# Ejemplos de uso
+
+## Ejemplo 1 — Modo médico (oncología)
+
+**Usuario**: "Investiga a fondo la evidencia actual sobre pembrolizumab en cáncer gástrico avanzado HER2-negativo."
+
+**Flujo**:
+1. Paso 0 → tema biomédico → modo médico.
+2. Plan: subpreguntas (a) eficacia en 1ª línea, (b) perfil de seguridad, (c) qué dicen las guías ESMO/NCCN 2024–2025.
+3. Ronda 1 → 3 subagentes: dos usan `search_articles` (filtro `Randomized Controlled Trial[Publication Type]`, `date_from=2020`), uno busca las guías.
+4. Texto completo: `convert_article_ids` → PMCID → `get_full_text_article` para los KEYNOTE relevantes; los de pago (NEJM) → vía proxy con Chrome MCP.
+5. Conflicto detectado entre subgrupos PD-L1 → ronda 2 con `find_related_articles` + meta-análisis.
+6. `report.md` con resumen, hallazgos por subpregunta, tabla de conflictos (confianza por subgrupo CPS), referencias con PMID+DOI, atribución a PubMed.
+7. `report.html` compartible.
+
+**Output esperado**: reporte donde cada afirmación de eficacia lleva su PMID/DOI, las guías citadas con fecha, y los subgrupos donde la evidencia es Baja están marcados.
+
+## Ejemplo 2 — Modo web (regulatorio/negocio)
+
+**Usuario**: "Deep research sobre los requisitos legales para facturación electrónica de un profesional sanitario independiente en Colombia en 2026."
+
+**Flujo**:
+1. Paso 0 → no biomédico → modo web, foco en fuentes oficiales (DIAN, normativa).
+2. Plan: (a) normativa vigente DIAN, (b) plazos/obligados 2026, (c) requisitos técnicos del proveedor tecnológico.
+3. Subagentes priorizan `.gov.co`, resoluciones DIAN, no blogs de asesorías.
+4. Gap: una pista venía de un blog → ronda 2 rastrea la resolución DIAN exacta que cita.
+5. Reporte con cada requisito ligado a su resolución oficial + fecha, y nota de vigencia.
+
+**Clave**: si solo hubiera blogs de gestorías, el reporte lo dice: "no localizado en fuente oficial DIAN; confirmar con la resolución".
+
+## Ejemplo 3 — Derivar a la skill ligera
+
+**Usuario**: "¿En qué año se aprobó el primer CAR-T?"
+
+→ Es un dato único. **No** se usa deep-research; se sugiere `strategy-web-research` o respuesta directa con una cita. Deep-research es para profundidad, no para datos sueltos.

--- a/.claude/skills/strategy/strategy-deep-research/references/medical-sources.md
+++ b/.claude/skills/strategy/strategy-deep-research/references/medical-sources.md
@@ -1,0 +1,73 @@
+# Modo médico — PubMed MCP + proxy universitario
+
+Para temas biomédicos/clínicos, PubMed es la fuente primaria. Este es el flujo.
+
+## MCP disponible: PubMed / PubMed Central (NCBI)
+
+Server `mcp__58c80515-b371-45ea-be47-178343711676__*`. Tools:
+
+| Tool | Para qué |
+|---|---|
+| `search_articles` | Buscar en PubMed. Acepta sintaxis: `[Title]`, `[Author]`, `[Journal]`, `[MeSH Terms]`, `[Publication Type]`, booleanos AND/OR/NOT, filtros `date_from`/`date_to`, `sort=relevance\|pub_date`. |
+| `get_article_metadata` | Abstract, autores, journal, DOI a partir de PMIDs. |
+| `get_full_text_article` | **Texto completo SOLO de PMC open-access** (~6M artículos). Recibe PMC IDs. |
+| `convert_article_ids` | PMID ↔ PMCID ↔ DOI. Útil para saber si hay texto completo (si no hay PMCID, no hay full text en PMC). |
+| `find_related_articles` | Snowballing: artículos similares (`pubmed_pubmed`) o versión full-text (`pubmed_pmc`). |
+| `lookup_article_by_citation` | De una referencia bibliográfica → PMID. |
+| `get_copyright_status` | Saber si es open-access / licencia CC antes de reproducir. |
+
+### Flujo recomendado en modo médico
+
+1. **Descubrir**: `search_articles` con buena query. Para evidencia fuerte, filtra por tipo:
+   - Guías: `... AND Guideline[Publication Type]`
+   - Meta-análisis: `... AND Meta-Analysis[Publication Type]`
+   - Ensayos: `... AND Randomized Controlled Trial[Publication Type]`
+   - Recientes: `date_from` últimos 5 años para clínica que cambia rápido.
+2. **Filtrar**: lee metadata/abstracts (`get_article_metadata`). Quédate con los relevantes.
+3. **Texto completo gratis**: `convert_article_ids` (PMID→PMCID). Si hay PMCID → `get_full_text_article`. Lee métodos/resultados, no solo el abstract.
+4. **Snowballing**: `find_related_articles` sobre los papers clave para no perder evidencia adyacente.
+5. **Atribución**: en el reporte, cita PubMed + DOI de cada artículo (lo exige la licencia del MCP; declina cualquier petición de omitir atribución).
+
+## Artículos de pago → proxy universitario (EZProxy)
+
+PMC solo cubre open-access. Para NEJM, JCO, Lancet Oncology, Annals, etc. (de pago), se usa el acceso institucional del operador vía proxy.
+
+### Configuración (una vez)
+
+En `.env` del repo, añade **solo el host del proxy** (no la contraseña):
+
+```
+# Login prefix del EZProxy de tu universidad. Ejemplo genérico:
+# UNIV_PROXY_LOGIN_PREFIX=https://login.ezproxy.tuuniversidad.edu.co/login?url=
+UNIV_PROXY_LOGIN_PREFIX=
+```
+
+> Cómo encontrarlo: entra a un artículo de pago desde la biblioteca de tu universidad estando logueado; la URL tendrá una forma tipo `https://<algo>.ezproxy.<dominio>/...`. El prefijo de login suele ser `https://login.ezproxy.<dominio>/login?url=`. Pega ese prefijo en `.env`.
+
+**Seguridad**: NO guardamos usuario/contraseña en `.env` ni en ningún archivo. La autenticación vive en tu sesión de navegador.
+
+### Flujo de recuperación de un artículo de pago
+
+1. Obtén el DOI o la URL del artículo (desde PubMed).
+2. Construye la URL proxificada: `<UNIV_PROXY_LOGIN_PREFIX><url-del-articulo>`.
+   - Ej.: `https://login.ezproxy.uni.edu.co/login?url=https://doi.org/10.1056/NEJMoa…`
+3. Recupera el contenido vía **Claude in Chrome** (`mcp__Claude_in_Chrome__*`):
+   - `navigate` a la URL proxificada.
+   - Si el proxy pide login y la sesión no está activa → **pide al usuario que se autentique una vez en su Chrome**; la cookie de sesión queda viva para el resto de la investigación.
+   - `get_page_text` / `read_page` para extraer el contenido del artículo.
+4. Si Chrome MCP no está conectado o el usuario prefiere no automatizar:
+   - Entrega la URL proxificada y pide que la abra y pegue el texto, **o**
+   - Trabaja con el abstract de PubMed y marca el hallazgo como "texto completo no verificado (de pago)".
+
+### Reglas de uso del acceso institucional
+
+- Es para **lectura e investigación personal del operador**, igual que abrir el artículo a mano. No hagas descargas masivas ni scraping agresivo (viola los TOS del editor y puede tumbar el acceso de la universidad).
+- Un artículo a la vez, a ritmo humano. Si necesitas muchos, prioriza los meta-análisis/guías.
+- Nunca redistribuyas el PDF; cita y resume.
+
+## Otras bases por dominio (no biomédico)
+
+- **arXiv / bioRxiv / medRxiv**: preprints (físics, CS, bio). Marca SIEMPRE como preprint (no peer-reviewed aún).
+- **clinicaltrials.gov**: registro de ensayos — Tier 0 para diseño/estado de un trial.
+- **Cochrane Library**: revisiones sistemáticas de altísima calidad (vía proxy si es de pago).
+- **Normativa**: BOE, EUR-Lex, fichas técnicas AEMPS/FDA/EMA.

--- a/.claude/skills/strategy/strategy-deep-research/references/source-tiers.md
+++ b/.claude/skills/strategy/strategy-deep-research/references/source-tiers.md
@@ -1,0 +1,53 @@
+# Rúbrica de tiers de fuente
+
+Clasifica **toda** fuente antes de usarla. Solo Tier 0 y Tier 1 son **evidencia citable**. Tier 2–3 solo sirven como pista para llegar a la fuente primaria.
+
+## Tier 0 — Fuente primaria / origen
+
+La autoridad máxima: el dato nace aquí.
+
+- Artículos peer-reviewed (PubMed/PMC, journals indexados), preprints con DOI (arXiv, bioRxiv) marcados como tal.
+- Guías de práctica clínica de sociedades científicas (NCCN, ESMO, ASCO, OMS, ministerios de salud).
+- Normativa y legislación oficial (BOE, leyes, decretos, fichas técnicas de medicamentos AEMPS/FDA/EMA).
+- Datos primarios de organismos oficiales (INE, Eurostat, WHO, CDC, registros de ensayos clinicaltrials.gov).
+- Documentación oficial del fabricante para la versión vigente (docs de un framework, API reference oficial).
+- Documentos originales: sentencias, patentes, informes anuales (10-K), actas oficiales.
+
+## Tier 1 — Secundaria autorizada / institucional
+
+Sintetiza Tier 0 con rigor y autoría responsable.
+
+- Revisiones sistemáticas y meta-análisis (de hecho suelen ser lo más útil).
+- Informes de organismos reconocidos (IARC, agencias gubernamentales, think tanks con metodología pública).
+- Universidades y centros de investigación (`.edu`, `.ac.*`) publicando sobre su área.
+- Medios de referencia con corrección y autoría (cobertura factual, no opinión), citando fuentes Tier 0.
+- Enciclopedias técnicas con control editorial y referencias (no foros).
+
+## Tier 2 — Terciaria / divulgativa
+
+Útil para orientarse y encontrar Tier 0–1, **nunca** como cita de autoridad.
+
+- Blogs corporativos y de expertos (incluso buenos): rastrea la fuente que citan.
+- Agregadores de noticias, newsletters, posts de LinkedIn/Medium.
+- Wikipedia: úsala SOLO como índice hacia sus referencias Tier 0–1, nunca se cita Wikipedia directamente.
+- Documentación no oficial / tutoriales de terceros.
+
+## Tier 3 — No verificable
+
+Descartar como evidencia.
+
+- Foros (Reddit, Quora, Stack Overflow para hechos médicos/legales), comentarios.
+- Contenido sin autor ni fecha, contenido generado por IA sin fuentes.
+- Sitios con conflicto de interés evidente que venden lo que afirman (marketing disfrazado de estudio).
+
+## Señales de calidad a verificar en cada fuente
+
+- **Fecha**: ¿publicación y último update? Antigüedad relevante para el tema → marca ⚠️.
+- **Autoría**: ¿quién firma? ¿tiene credenciales/responsabilidad sobre lo que dice?
+- **Citas**: ¿la fuente cita a su vez fuentes verificables, o afirma en el vacío?
+- **Conflicto de interés**: ¿quién paga / qué vende el sitio?
+- **Reproducibilidad**: ¿puedo llegar al dato primario desde aquí?
+
+## Regla de oro
+
+> Si una afirmación solo se sostiene en Tier 2–3, **no es un hecho establecido**. Repórtala como "según fuentes secundarias, no confirmado en fuente primaria" — o sigue buscando hasta encontrar Tier 0–1.

--- a/.claude/skills/strategy/strategy-deep-research/references/subagent-brief.md
+++ b/.claude/skills/strategy/strategy-deep-research/references/subagent-brief.md
@@ -1,0 +1,54 @@
+# Plantilla de instrucción para subagentes de búsqueda
+
+Cada subagente investiga **una** subpregunta y escribe a archivo. Debe ser autocontenido (no conoce el resto de la conversación).
+
+## Plantilla (modo web)
+
+```
+Investiga esta pregunta concreta: "<SUBPREGUNTA SIN ACRÓNIMOS>".
+
+Contexto: forma parte de una investigación profunda sobre <TEMA>. Solo necesito ESTA subpregunta.
+
+Reglas de fuentes (CRÍTICO):
+- Prioriza fuentes PRIMARIAS y OFICIALES: organismos (.gov, .edu, OMS, agencias),
+  papers, normativa, documentación oficial del fabricante. 
+- Los blogs, Medium, LinkedIn, foros y Wikipedia NO cuentan como evidencia: úsalos solo
+  para encontrar la fuente primaria que citan, y luego ve a esa fuente.
+- Anota la fecha de publicación de cada fuente. Marca las que sean viejas para el tema.
+
+Presupuesto: 4–6 búsquedas web. Usa WebSearch para descubrir y WebFetch/Firecrawl para leer.
+
+Cuando termines, usa Write para guardar tus hallazgos en:
+  projects/strategy-deep-research/<CARPETA>/findings-<slug-subpregunta>.md
+
+Formato de cada hallazgo en ese archivo:
+  - **Afirmación**: <qué encontraste>
+  - **Cita literal** (si aplica): "<texto exacto>"
+  - **Fuente**: <título> — <autor/organismo>
+  - **URL**: <url>
+  - **Publicado**: <fecha> · **Tier estimado**: <0|1|2|3>
+
+No sintetices ni des conclusiones globales: solo recopila hallazgos citados. Si solo
+encuentras fuentes Tier 2–3, dilo explícitamente.
+```
+
+## Plantilla (modo médico)
+
+Igual que arriba, pero sustituye la estrategia de búsqueda:
+
+```
+Usa las tools del MCP de PubMed:
+- mcp__58c80515-b371-45ea-be47-178343711676__search_articles para buscar
+  (filtra por Meta-Analysis[Publication Type] / Guideline[Publication Type] / 
+   Randomized Controlled Trial[Publication Type] cuando busques evidencia fuerte;
+   usa date_from para limitar a los últimos años si la clínica cambia rápido).
+- get_article_metadata para abstracts/DOIs.
+- convert_article_ids (PMID→PMCID) y get_full_text_article para texto completo open-access.
+Registra PMID y DOI de cada artículo (atribución obligatoria a PubMed).
+Para artículos de pago sin PMC, registra el abstract + DOI y márcalo como
+"texto completo pendiente vía proxy".
+```
+
+## Por qué a archivo y no en prosa
+
+Los subagentes devuelven mucho texto. Escribir a archivo mantiene limpio el contexto del agente principal y permite releer hallazgos en la síntesis sin re-buscar.

--- a/.claude/skills/strategy/strategy-prd-builder/SKILL.md
+++ b/.claude/skills/strategy/strategy-prd-builder/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: strategy-prd-builder
+description: Crea PRDs (Documentos de Requisitos de Producto) para productos de cualquier categoría — app de software, SaaS, no-code/automatización, o producto de marca/contenido. Usar cuando el usuario quiere arrancar un proyecto nuevo, "hazme un PRD", "documento de requisitos", "especificación de producto", "definir el producto antes de construir", o necesita pasar de una idea a un plan ejecutable. Genera SIEMPRE dos archivos .md revisables en bloc de notas: PRD.md (documento de decisión — problema, usuarios, requisitos, métricas) y, aparte, PASO-A-PASO.md (playbook de construcción con prompts numerados estilo "paso a paso" listos para pegar en Claude Code). El paso a paso NUNCA va embebido en el PRD. HTML opcional.
+version: 1.0.0
+category: strategy
+---
+
+# Strategy PRD Builder
+
+Convierte una idea de producto en **dos archivos `.md` que se revisan en bloc de notas**:
+
+1. **`PRD.md`** — documento de decisión (problema, usuarios, requisitos, métricas, alcance). El *qué* y el *porqué*.
+2. **`PASO-A-PASO.md`** — playbook de construcción con prompts numerados listos para ejecutar. El *cómo*. **Regla fija: siempre archivo aparte, NUNCA embebido en el PRD.**
+
+El paso a paso está anclado al formato del documento `PASO A PASO Windows.md` de ARC-Whisper: claro, ordenado, replicable.
+
+## Cuándo usar esta skill
+
+- El usuario arranca un proyecto nuevo y dice "hazme un PRD", "documento de requisitos", "especificación"
+- Quiere definir un producto **antes** de construirlo
+- Necesita pasar de una idea difusa a un plan ejecutable por Claude Code
+- Quiere un documento que cualquiera pueda leer en un bloc de notas y entender qué se construye y por qué
+
+## Qué la hace distinta
+
+| Skill | Cuándo |
+|---|---|
+| `strategy-prd-builder` | Definir un **producto** y dejar el plan listo para construir |
+| `strategy-deep-research` | Investigar a fondo un tema con fuentes citadas |
+| `arnes` (opcional) | Scaffolding de archivos del proyecto software ya decidido |
+| `seis-sombreros` | Decisión estratégica con perspectivas múltiples |
+
+Un PRD **no** es un playbook de construcción puro ni una investigación. Es el puente: el `PRD.md` decide qué construir y el `PASO-A-PASO.md` (archivo aparte) deja los prompts para construirlo.
+
+## Categorías de producto soportadas
+
+La skill adapta el PRD según la categoría. Si el usuario no la dice, **pregúntala** (una sola pregunta):
+
+1. **App de software** — app instalable o web (ej. ARC-Whisper, historias-clínicas). Énfasis en arquitectura, stack, estructura de archivos, prompts de build.
+2. **SaaS** — producto multi-usuario con cuentas, planes, deploy. Añade modelo de datos, auth, pricing/planes, métricas de retención.
+3. **No-code / automatización** — Forms + Excel, n8n, Zapier (ej. qr-demanda-no-atendida). El "playbook" son pasos de configuración, no prompts de código.
+4. **Marca / contenido** — pipeline de contenido, producto informativo (ej. pipeline-video-sin-cara). El "playbook" son pasos de producción/distribución.
+
+El esqueleto del PRD es el mismo; cambian el énfasis y el contenido del `PASO-A-PASO.md`.
+
+## Proceso
+
+### 1. Recolectar lo mínimo (entrevista corta)
+
+No interrogues. Pregunta solo lo que falte para llenar el PRD. Prioriza:
+
+- **Qué es** el producto en una frase
+- **Para quién** (usuario/ICP) y **qué dolor** resuelve
+- **Categoría** (de la lista de arriba)
+- **Stack/herramientas** previstas (si las hay)
+- **Qué NO hace** (alcance) — pregunta clave que casi nadie da gratis
+- **Cómo se mide el éxito**
+
+Si el usuario ya dio un documento de referencia (como `PASO A PASO Windows.md`), extráelo de ahí en vez de preguntar.
+
+### 2. Aplicar buenas prácticas
+
+Lee `references/prd-best-practices.md` y aplícalo. Reglas no negociables:
+
+- **Problema antes que solución.** La parte 1 abre con el problema, no con la feature.
+- **El "qué" y el "porqué", no el "cómo"** en la parte de requisitos. El "cómo" vive en el playbook (parte 2).
+- **Métricas medibles.** Nada de "mejorar la experiencia". Sí "el 80% de los dictados se insertan sin editar".
+- **Alcance explícito.** Siempre una sección "Lo que NO hacemos".
+- **User stories** en formato `Como [usuario], quiero [acción] para [beneficio]`.
+- **Requisitos funcionales vs no funcionales** separados.
+- **Documento vivo, conciso.** Si una sección no aplica a la categoría, omítela en vez de rellenarla con paja. Respeta `[[feedback_no_inventar_en_perfiles]]`: campo sin dato → se deja explícito como "Pendiente", no se inventa.
+
+### 3. Generar dos archivos separados (regla fija)
+
+Genera **siempre dos `.md`**, nunca uno solo:
+
+**a) `PRD.md`** — el documento de decisión. Usa `templates/prd-template.md`. Contiene las secciones de decisión (objetivo, usuarios, métricas, supuestos, user stories, requisitos funcionales/no funcionales, alcance, riesgos, preguntas abiertas) + un **puntero** al paso a paso.
+
+**b) `PASO-A-PASO.md`** — el playbook de construcción, **archivo aparte**. Regla no negociable: el paso a paso **nunca** se embebe dentro del PRD; vive como `.md` independiente para abrirlo solo en un bloc de notas mientras se construye. Usa `templates/paso-a-paso-template.md` e imita el estilo de `PASO A PASO Windows.md`:
+
+- Prompts **numerados** ("Prompt 1 — …") en bloques de código, listos para copiar/pegar
+- Cada prompt autocontenido: que Claude Code pueda ejecutarlo sin contexto extra
+- Sección "Lo que hace el usuario (no Claude Code)" para pasos manuales (pegar API keys, permisos, etc.)
+- Estructura de archivos esperada cuando sea app de software
+
+### 4. Guardar el output
+
+Los **dos** archivos van juntos en la carpeta del proyecto:
+
+- `projects/briefs/<nombre>/PRD.md`
+- `projects/briefs/<nombre>/PASO-A-PASO.md`
+
+(o, si es single-task, ambos bajo `projects/strategy-prd-builder/<YYYY-MM-DD>-<titulo>/`).
+
+- Ambos `.md` son la fuente de verdad — se revisan en bloc de notas sin renderizar.
+- El `PRD.md` enlaza al `PASO-A-PASO.md` y viceversa, para no perder la conexión.
+- **HTML opcional**: si el usuario lo pide, invoca `tool-visual-explainer` para una versión presentable.
+
+## Output
+
+Tras generar, confirma:
+- Rutas de **ambos** archivos: `PRD.md` y `PASO-A-PASO.md`
+- Categoría detectada
+- Secciones incluidas / omitidas (y por qué)
+- Siguiente paso sugerido (ej. "`/install-skill arnes` para scaffolding" o "ejecuta el Prompt 1")
+
+## Referencias
+
+- `references/prd-best-practices.md` — buenas prácticas destiladas de fuentes reales (Atlassian, Maze, Lenny's, Figma). Léelo antes de escribir.
+- `templates/prd-template.md` — esqueleto del PRD (documento de decisión).
+- `templates/paso-a-paso-template.md` — esqueleto del paso a paso (playbook, archivo aparte).
+- Ejemplo canónico de la parte 2 (playbook): `projects/arc-whisper/PASO A PASO Windows.md`.

--- a/.claude/skills/strategy/strategy-prd-builder/references/prd-best-practices.md
+++ b/.claude/skills/strategy/strategy-prd-builder/references/prd-best-practices.md
@@ -1,0 +1,61 @@
+# Buenas prácticas de PRD (destiladas)
+
+> Síntesis de fuentes reales consultadas el 2026-05-30: Atlassian (Agile/Requirements), Maze, Lenny's Newsletter, Figma resource library. Aplica esto al escribir cualquier PRD con `strategy-prd-builder`.
+
+## Principios rectores
+
+1. **Problema antes que solución.** Empieza por el dolor del usuario y el "porqué", no por la lista de features. Un PRD que abre con features está mal planteado.
+2. **El "qué" y el "porqué", nunca el "cómo".** Los requisitos describen comportamiento esperado, no implementación. El "cómo" (stack, prompts, pasos) va en el playbook (parte 2 del PRD híbrido).
+3. **Documento vivo y conciso.** Atlassian: "mejor escribir requisitos de forma ligera y ajustarlos constantemente que pasar semanas en un documento que queda obsoleto." Enlaza a material de apoyo en vez de meterlo todo dentro.
+4. **Colaborativo, no aislado.** Un PRD escrito en una cueva sin validar con stakeholders/usuarios es un error recurrente.
+5. **Métricas medibles o no sirven.** Toda meta lleva un número y un plazo.
+6. **Alcance explícito.** La sección "Lo que NO hacemos" evita el scope creep y aclara expectativas. Es la sección que más se omite y más valor da.
+
+## Secciones canónicas (intersección de las fuentes)
+
+| Sección | Qué responde | Obligatoria |
+|---|---|---|
+| Objetivo / visión | ¿Por qué existe esto? ¿Qué problema resuelve? | Sí |
+| Métricas de éxito | ¿Cómo sabremos que funcionó? (número + plazo) | Sí |
+| Usuarios / personas / ICP | ¿Para quién? | Sí |
+| Supuestos | ¿Qué damos por cierto? (técnico y de negocio) | Recomendada |
+| User stories / escenarios | ¿Cómo lo usan? | Sí |
+| Requisitos funcionales | ¿Qué debe hacer el sistema? | Sí |
+| Requisitos no funcionales | ¿Cómo debe rendir? (perf, seguridad, privacidad, escalabilidad) | Según categoría |
+| Diseño / wireframes / flujo | ¿Cómo se ve y se navega? | Si aplica |
+| Alcance — "Lo que NO hacemos" | Límites explícitos | Sí |
+| Riesgos y dependencias | ¿Qué puede salir mal? ¿De qué depende? | Recomendada |
+| Timeline / hitos | ¿Cuándo? | Recomendada |
+| Preguntas abiertas | ¿Qué falta decidir? | Recomendada |
+
+## Formatos estándar
+
+- **User story**: `Como [tipo de usuario], quiero [acción] para [beneficio/valor].`
+- **Métrica de éxito** (estilo Atlassian): `[Categoría]: [número]% de [usuarios] [hace acción] dentro de [plazo].`
+  Ejemplo: "Adopción: 80% de los dictados se insertan sin que el usuario los edite, en la primera semana."
+- **Requisito funcional**: verbo de comportamiento observable. "El sistema transcribe el audio al soltar la tecla." NO "usar faster-whisper" (eso es el cómo → playbook).
+- **Requisito no funcional**: atributo de calidad medible. "La transcripción de 30s termina en < 5s en CPU."
+
+## Errores comunes a evitar
+
+- Ser demasiado vago **o** demasiado detallado (sobre-especificar implementación).
+- Saltarse la investigación de usuario.
+- No definir métricas de éxito claras.
+- Tratarlo como documento estático que nadie vuelve a tocar.
+- Trabajar en aislamiento sin input de stakeholders.
+- Enfocarse en soluciones antes de entender el problema.
+- Rellenar secciones que no aplican con paja. Si no aplica, omítela o márcala "Pendiente".
+
+## Adaptación por categoría
+
+- **App de software**: fuerte en requisitos funcionales + estructura de archivos + playbook de prompts de build.
+- **SaaS**: añade modelo de datos, auth/roles, planes/pricing, métricas de retención y activación.
+- **No-code / automatización**: requisitos funcionales como pasos de flujo; el playbook son pasos de configuración (Forms, Excel, n8n), no código.
+- **Marca / contenido**: "requisitos" = especificación del entregable (formato, duración, canal, voz); el playbook es el pipeline de producción y distribución.
+
+## Fuentes
+
+- Atlassian — How to Write a PRD / What is a PRD: https://www.atlassian.com/agile/product-management/requirements
+- Maze — Product Requirements Document: How-to & Examples: https://maze.co/blog/product-requirements-document/
+- Lenny's Newsletter — My favorite templates: PRDs, strategy, processes: https://www.lennysnewsletter.com/p/my-favorite-templates-prds-strategy
+- Figma — 15 Best PRD Templates 2025: https://www.figma.com/resource-library/product-requirements-document-templates/

--- a/.claude/skills/strategy/strategy-prd-builder/templates/paso-a-paso-template.md
+++ b/.claude/skills/strategy/strategy-prd-builder/templates/paso-a-paso-template.md
@@ -1,0 +1,47 @@
+# PASO A PASO — {{NOMBRE_DEL_PRODUCTO}}
+
+> Playbook de construcción · Fecha: {{YYYY-MM-DD}}
+> 📄 Decisión y requisitos: **[`PRD.md`](./PRD.md)**
+> Cómo usar: abre este archivo en un bloc de notas y pega los prompts en Claude Code, en orden.
+
+## Stack / herramientas
+
+- {{lenguaje, frameworks, servicios, MCPs}}
+
+## Estructura de archivos esperada
+<!-- Solo para app/SaaS. Omitir en no-code/contenido. -->
+
+```
+{{nombre-proyecto}}/
+  {{...}}
+```
+
+## Prompts en orden
+
+### Prompt 1 — {{verificar entorno / preparar}}
+
+```
+{{prompt autocontenido, listo para pegar}}
+```
+
+### Prompt 2 — {{...}}
+
+```
+{{...}}
+```
+
+### Prompt N — {{construir / verificar que funciona}}
+
+```
+{{...}}
+```
+
+## Lo que hace el usuario (no Claude Code)
+
+> Pasos manuales que no se pueden automatizar.
+
+1. {{pegar API key, dar permisos, etc.}}
+
+## Notas y personalización
+
+- {{cómo cambiar comportamiento sin reconstruir, variantes por caso de uso}}

--- a/.claude/skills/strategy/strategy-prd-builder/templates/prd-template.md
+++ b/.claude/skills/strategy/strategy-prd-builder/templates/prd-template.md
@@ -1,0 +1,70 @@
+# PRD — {{NOMBRE_DEL_PRODUCTO}}
+
+> Documento de Requisitos de Producto · Categoría: {{CATEGORIA}} · Fecha: {{YYYY-MM-DD}} · Autor: Dr. Juan Camilo Paris
+> Estado: {{borrador | activo | aprobado}}
+> 🔧 Paso a paso de construcción: **[`PASO-A-PASO.md`](./PASO-A-PASO.md)** (archivo aparte, revisable en bloc de notas)
+
+> Este documento define **qué** se construye y **por qué**. El **cómo** (prompts de construcción) vive en `PASO-A-PASO.md`.
+
+## 1. Objetivo y problema
+
+**En una frase:** {{qué es el producto}}
+
+**El problema:** {{qué dolor real resuelve, para quién, por qué importa ahora}}
+
+## 2. Usuarios / ICP
+
+- **Usuario principal:** {{persona, contexto, nivel técnico}}
+- **Usuarios secundarios:** {{si aplica}}
+
+## 3. Métricas de éxito
+
+> Número + plazo. Sin números no es métrica.
+
+- {{Categoría}}: {{X% de [usuarios] [hace acción] en [plazo]}}
+- ...
+
+## 4. Supuestos
+
+- {{supuesto técnico o de negocio que damos por cierto}}
+
+## 5. User stories
+
+- Como {{usuario}}, quiero {{acción}} para {{beneficio}}.
+- ...
+
+## 6. Requisitos funcionales
+
+> Comportamiento observable. El "qué", no el "cómo".
+
+| # | Requisito | Prioridad (P0/P1/P2) |
+|---|---|---|
+| RF1 | {{El sistema...}} | P0 |
+
+## 7. Requisitos no funcionales
+
+> Solo los que apliquen a la categoría. Omitir el resto.
+
+- **Rendimiento:** {{ej. transcribir 30s en < 5s}}
+- **Privacidad / seguridad:** {{ej. datos clínicos anonimizados, nada sale del equipo}}
+- **Plataforma:** {{Windows / web / móvil}}
+
+## 8. Alcance — Lo que NO hacemos
+
+> La sección que más valor da. Sé explícito.
+
+- {{fuera de alcance en esta versión}}
+
+## 9. Riesgos y dependencias
+
+| Riesgo / dependencia | Impacto | Mitigación |
+|---|---|---|
+| {{...}} | {{alto/medio/bajo}} | {{...}} |
+
+## 10. Preguntas abiertas
+
+- [ ] {{decisión pendiente}}
+
+---
+
+> ▶️ Para construir: abre **[`PASO-A-PASO.md`](./PASO-A-PASO.md)** y sigue los prompts en orden.

--- a/.claude/skills/visualization/tool-visual-explainer/SKILL.md
+++ b/.claude/skills/visualization/tool-visual-explainer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tool-visual-explainer
-description: Genera páginas HTML autocontenidas y bonitas que explican visualmente sistemas, código, planes, datos o análisis. Úsalo cuando necesites compartir un output complejo (diagrama, comparativa, recap de proyecto, plan review, tabla larga) o cuando otra skill (welcome-quick-win, seis-sombreros, marketing-positioning) cierre con material que el usuario querrá compartir por WhatsApp/Skool/email. Output: HTML5 sin dependencias externas, móvil-first, paleta sobria con acento naranja iAmasters.
+description: Genera páginas HTML autocontenidas y bonitas que explican visualmente sistemas, código, planes, datos o análisis. Úsalo cuando necesites compartir un output complejo (diagrama, comparativa, recap de proyecto, plan review, tabla larga) o cuando otra skill (welcome-quick-win, seis-sombreros, marketing-positioning) cierre con material que el usuario querrá compartir por WhatsApp/Skool/email. Output: HTML5 sin dependencias externas, móvil-first, modo claro por defecto, paleta clínica sobria (azul confianza) con firma de Juan Camilo Paris.
 ---
 
 # tool-visual-explainer
@@ -51,143 +51,136 @@ Antes de generar:
 
 ### Paso 3 · Generar HTML
 
-Usa este esqueleto base. Es deliberadamente simple — no compitas con sitios webs, **prioriza legibilidad y portabilidad**.
+Usa este esqueleto base. Es la **forma fija de marca**: hero con degradado, secciones numeradas secuenciales y tarjetas. Prioriza legibilidad, portabilidad (sin JS) y que **todos los HTML salgan con la misma estructura**. Para cambiar la identidad visual, edita solo el bloque `:root`.
 
 ```html
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{ title }}</title>
-  <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      line-height: 1.6;
-      color: #1a1a1a;
-      background: #fafafa;
-      padding: 24px 16px;
-    }
-    .container {
-      max-width: 720px;
-      margin: 0 auto;
-      background: white;
-      border-radius: 12px;
-      padding: 32px 24px;
-      box-shadow: 0 1px 3px rgba(0,0,0,0.06);
-    }
-    .hero {
-      border-bottom: 2px solid #ff8c42;
-      padding-bottom: 16px;
-      margin-bottom: 24px;
-    }
-    .hero h1 { font-size: 28px; color: #1a1a1a; margin-bottom: 8px; }
-    .hero .meta { color: #666; font-size: 14px; }
-    h2 {
-      font-size: 20px;
-      color: #1a1a1a;
-      margin-top: 32px;
-      margin-bottom: 12px;
-      border-left: 4px solid #ff8c42;
-      padding-left: 12px;
-    }
-    h3 { font-size: 16px; margin-top: 20px; margin-bottom: 8px; color: #333; }
-    p { margin-bottom: 12px; }
-    ul, ol { padding-left: 24px; margin-bottom: 16px; }
-    li { margin-bottom: 6px; }
-    blockquote {
-      border-left: 4px solid #b794f4;
-      background: #faf5ff;
-      padding: 12px 16px;
-      margin: 16px 0;
-      border-radius: 4px;
-      color: #4a4a4a;
-      font-style: italic;
-    }
-    table {
-      width: 100%;
-      border-collapse: collapse;
-      margin: 16px 0;
-      font-size: 14px;
-    }
-    th, td { padding: 10px 12px; text-align: left; border-bottom: 1px solid #e0e0e0; }
-    th { background: #f5f5f5; font-weight: 600; color: #333; }
-    tr:hover { background: #fafafa; }
-    .metric-card {
-      background: #fff7ed;
-      border: 1px solid #fed7aa;
-      border-radius: 8px;
-      padding: 16px;
-      margin: 12px 0;
-    }
-    .metric-card .label { font-size: 13px; color: #666; }
-    .metric-card .value { font-size: 24px; font-weight: bold; color: #ff8c42; }
-    pre, code {
-      font-family: "SF Mono", Monaco, Consolas, monospace;
-      background: #f5f5f5;
-      padding: 2px 6px;
-      border-radius: 3px;
-      font-size: 13px;
-    }
-    pre { padding: 12px; overflow-x: auto; }
-    .cta {
-      background: linear-gradient(135deg, #ff8c42, #ffa66f);
-      color: white;
-      padding: 16px 20px;
-      border-radius: 8px;
-      margin: 20px 0;
-      text-align: center;
-      font-weight: 600;
-    }
-    .cta a { color: white; text-decoration: underline; }
-    footer {
-      margin-top: 32px;
-      padding-top: 16px;
-      border-top: 1px solid #e0e0e0;
-      color: #888;
-      font-size: 12px;
-      text-align: center;
-    }
-    @media (max-width: 640px) {
-      body { padding: 12px 8px; }
-      .container { padding: 20px 16px; border-radius: 8px; }
-      .hero h1 { font-size: 22px; }
-    }
-  </style>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{ title }}</title>
+<style>
+  /* Paleta de marca — Juan Camilo Paris (azul confianza, modo claro). */
+  :root{
+    --primary:#1D4E89; --primary-2:#2E6FA8; --accent:#4FB0C6; --warm:#F2A65A;
+    --ink:#16202B; --muted:#5A6675; --bg:#EAF0F8; --panel:#FFFFFF; --panel2:#F1F5FB; --line:#DDE6F0;
+    --hi:#1E7A52; --hi-bg:#E3F3EA; --med:#B26A00; --med-bg:#FBEFD9; --lo:#B3261E; --lo-bg:#FBE6E4;
+    --shadow:0 6px 24px rgba(16,32,43,.08);
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:880px;margin:0 auto;padding:28px 18px 70px}
+  /* Hero con degradado */
+  .hero{position:relative;overflow:hidden;border-radius:18px;padding:34px 30px 30px;background:linear-gradient(135deg,#173F70 0%,var(--primary) 45%,var(--accent) 130%);color:#fff;box-shadow:var(--shadow)}
+  .hero::after{content:"";position:absolute;right:-60px;top:-60px;width:220px;height:220px;background:radial-gradient(circle,rgba(255,255,255,.14),transparent 70%);border-radius:50%}
+  .kicker{display:inline-block;font-size:12px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:#0c2746;background:var(--warm);padding:4px 11px;border-radius:999px;margin-bottom:14px}
+  .hero h1{font-size:29px;line-height:1.22;margin:0 0 16px;font-weight:800;max-width:42ch}
+  .meta{display:flex;gap:8px;flex-wrap:wrap}
+  .meta .pill{font-size:12px;background:rgba(255,255,255,.16);border:1px solid rgba(255,255,255,.28);color:#fff;border-radius:999px;padding:4px 11px}
+  /* Secciones numeradas (secuenciales) */
+  section{background:var(--panel);border:1px solid var(--line);border-radius:16px;padding:22px 22px 6px;margin:18px 0;box-shadow:var(--shadow)}
+  .sec-head{display:flex;align-items:center;gap:12px;margin:2px 0 14px}
+  .sec-num{flex:none;width:34px;height:34px;border-radius:10px;display:grid;place-items:center;background:linear-gradient(135deg,var(--primary),var(--primary-2));color:#fff;font-weight:800;font-size:15px;box-shadow:0 2px 8px rgba(29,78,137,.35)}
+  .sec-head h2{margin:0;font-size:19px;color:var(--ink);font-weight:750}
+  h3{font-size:15px;color:var(--primary);margin:20px 0 8px;font-weight:700}
+  p{margin:10px 0} a{color:var(--primary)}
+  section ul,section ol{margin:8px 0 16px;padding-left:20px} section li{margin:7px 0}
+  sup a{color:var(--primary);text-decoration:none;font-weight:700}
+  /* Chips (definiciones / abreviaturas) */
+  .chips{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:10px;margin:6px 0 16px}
+  .chips .item{display:flex;gap:10px;align-items:flex-start;background:var(--panel2);border:1px solid var(--line);border-radius:10px;padding:9px 11px}
+  .chips .sig{flex:none;font-size:12px;font-weight:800;color:#fff;background:var(--primary);border-radius:7px;padding:3px 8px;min-width:46px;text-align:center}
+  .chips .term{font-size:13px;color:var(--muted);line-height:1.4}
+  /* KPIs / métricas */
+  .kpi{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px;margin:6px 0 18px}
+  .kpi .k{background:var(--panel2);border:1px solid var(--line);border-top:3px solid var(--warm);border-radius:12px;padding:14px}
+  .kpi .v{font-size:23px;font-weight:800;color:var(--primary);letter-spacing:-.01em} .kpi .l{font-size:12px;color:var(--muted);margin-top:3px}
+  /* Tablas */
+  .tablewrap{border:1px solid var(--line);border-radius:12px;overflow:hidden;margin:14px 0}
+  table{width:100%;border-collapse:collapse;font-size:14px}
+  th,td{padding:10px 12px;text-align:left;vertical-align:top;border-bottom:1px solid var(--line)}
+  thead th{background:var(--primary);color:#fff;font-weight:650;border-bottom:none}
+  tbody tr:nth-child(even){background:var(--panel2)} tbody tr:last-child td{border-bottom:none}
+  td code{color:var(--primary);font-weight:600}
+  /* Badges / callout / vacíos */
+  .badge{display:inline-block;border-radius:999px;padding:2px 10px;font-size:12px;font-weight:700}
+  .b-hi{background:var(--hi-bg);color:var(--hi);border:1px solid var(--hi)}
+  .b-med{background:var(--med-bg);color:var(--med);border:1px solid var(--med)}
+  .b-lo{background:var(--lo-bg);color:var(--lo);border:1px solid var(--lo)}
+  .callout{background:var(--panel2);border-left:4px solid var(--accent);border-radius:8px;padding:12px 14px;margin:14px 0;color:#27323c}
+  .gap{background:#FFF8EF;border:1px solid #F6E0C2;border-left:4px solid var(--warm);border-radius:12px;padding:6px 18px;margin:8px 0 14px}
+  .small{font-size:13px;color:var(--muted)}
+  /* Código / CTA */
+  pre,code{font-family:"SF Mono",Monaco,Consolas,monospace;background:#EEF1F6;border-radius:4px;font-size:13px}
+  code{padding:2px 6px} pre{padding:12px;overflow-x:auto}
+  .cta{background:linear-gradient(135deg,var(--primary),var(--accent));color:#fff;padding:16px 20px;border-radius:10px;margin:16px 0;text-align:center;font-weight:700}
+  .cta a{color:#fff;text-decoration:underline}
+  /* Referencias numeradas */
+  .refs{counter-reset:r;list-style:none;padding:0;margin:6px 0 8px}
+  .refs li{position:relative;padding:10px 0 10px 40px;border-bottom:1px solid var(--line);font-size:13px;color:#37424d}
+  .refs li:last-child{border-bottom:none}
+  .refs li::before{counter-increment:r;content:counter(r);position:absolute;left:0;top:10px;width:26px;height:26px;border-radius:8px;background:var(--panel2);border:1px solid var(--line);color:var(--primary);font-weight:800;font-size:12px;display:grid;place-items:center}
+  .refs a{color:var(--primary);text-decoration:none}
+  .note{font-size:12px;color:var(--muted);margin:10px 0 0}
+  footer{text-align:center;color:var(--muted);font-size:13px;margin-top:26px} footer .sig{font-weight:700;color:var(--primary)}
+  @media(max-width:560px){.hero h1{font-size:23px}.wrap{padding:18px 12px 50px}section{padding:18px 16px 4px}}
+</style>
 </head>
 <body>
-  <div class="container">
-    <header class="hero">
-      <h1>{{ title }}</h1>
-      <div class="meta">{{ subtitle }} · {{ date }}</div>
-    </header>
+<div class="wrap">
 
-    <!-- Renderiza cada bloque según su tipo -->
-    {{ blocks }}
+  <header class="hero">
+    <span class="kicker">{{ kicker }}</span>      <!-- etiqueta corta opcional -->
+    <h1>{{ title }}</h1>
+    <div class="meta">{{ meta_pills }}</div>       <!-- un <span class="pill">…</span> por metadato -->
+  </header>
 
-    <footer>
-      Generado por iAmasters OS · <a href="https://iamastersacademy.com">iamastersacademy.com</a>
-    </footer>
-  </div>
+  <!-- Una <section> numerada por bloque temático, en orden secuencial 01, 02, … -->
+  {{ sections }}
+
+  <footer><span class="sig">Generado por Dr. Juan Camilo Paris</span></footer>
+
+</div>
 </body>
 </html>
 ```
 
 ### Paso 4 · Renderizar bloques
 
-Para cada bloque del input, usa estos templates:
+**Cada bloque temático va dentro de una `<section>` numerada secuencialmente** (01, 02, 03…). Esa es la "forma fija" que se repite en todos los HTML:
+
+```html
+<section>
+  <div class="sec-head"><span class="sec-num">01</span><h2>Título de la sección</h2></div>
+  <!-- aquí el contenido de la sección (uno o varios de los componentes de abajo) -->
+</section>
+```
+
+Componentes disponibles dentro de una sección:
 
 | Tipo | HTML |
 |---|---|
-| `text` | `<h2>{title}</h2><p>{body}</p>` |
-| `list` | `<h2>{title}</h2><ul>{items as <li>}</ul>` (o `<ol>` si numerada) |
-| `table` | `<h2>{title}</h2><table>{thead + tbody}</table>` |
-| `quote` | `<blockquote>{body}</blockquote>` |
-| `metric-card` | `<div class="metric-card"><div class="label">{label}</div><div class="value">{value}</div></div>` |
-| `code` | `<h2>{title}</h2><pre><code>{body}</code></pre>` |
+| `text` | `<p>{body}</p>` (usa `<h3>` para subtítulos dentro de la sección) |
+| `list` | `<ul><li>…</li></ul>` (o `<ol>`) |
+| `chips` (definiciones / abreviaturas) | `<div class="chips"><div class="item"><span class="sig">SIGLA</span><span class="term">término completo</span></div> …</div>` |
+| `kpi` (métricas clave) | `<div class="kpi"><div class="k"><div class="v">{valor}</div><div class="l">{etiqueta}</div></div> …</div>` |
+| `table` | `<div class="tablewrap"><table><thead><tr><th>…</th></tr></thead><tbody>…</tbody></table></div>` |
+| `badge` | `<span class="badge b-hi">Alta</span>` · `b-med` (ámbar) · `b-lo` (rojo) — para estados/confianza |
+| `callout` (idea clave) | `<div class="callout"><b>Título:</b> {body}</div>` |
+| `gap` (vacíos / pendientes) | `<div class="gap"><ul><li>…</li></ul></div>` |
+| `quote` | usa `callout` |
+| `code` | `<pre><code>{body}</code></pre>` |
 | `cta` | `<div class="cta">{body}</div>` |
-| `image` | `<img src="{src}" alt="{alt}" style="max-width:100%;border-radius:6px;">` (preferir SVG inline) |
+| `refs` (referencias) | `<ol class="refs"><li id="r1">…</li> …</ol>` (numeración automática) |
+| `image` | `<img src="{src}" alt="{alt}" style="max-width:100%;border-radius:10px;">` (preferir SVG inline) |
+
+**Reglas de composición (de la búsqueda de buenas prácticas):**
+- **Secuencial y numerado**: secciones en orden, con su `.sec-num`. Da una lectura guiada y la misma forma siempre.
+- **Un solo color de realce domina** (azul); celeste acompaña; ámbar es solo acento puntual (kicker, filo de KPI, vacíos).
+- **Máximo 3 niveles de jerarquía** de texto (h1 hero · h2 sección · h3 subtítulo).
+- **Aire y tarjetas**: cada sección es una tarjeta con margen; no amontonar.
+- El `metric-card` antiguo se reemplaza por `kpi`; `blockquote` por `callout`.
 
 ### Paso 5 · Guardar y reportar
 
@@ -228,12 +221,32 @@ Ninguna directamente. Esta skill es **invocada por** otras (`welcome-quick-win`,
 - **Contenido > 100KB**: dividir en múltiples HTMLs (uno por sección) o sugerir resumen.
 - **Tabla con >20 filas**: añadir scroll horizontal + considerar paginación visual.
 - **Idioma del contenido distinto a castellano**: respeta el idioma de input. El framework HTML (footer, meta) se mantiene en castellano salvo override.
-- **Usuario quiere paleta distinta a la naranja iAmasters**: aceptar override en input (`brand_color: "#XYZ"`). Default mantiene paleta del OS.
+- **Usuario quiere paleta distinta a la de marca**: aceptar override en input (`brand_color: "#XYZ"` o un set de variables). Default mantiene la paleta de marca (azul confianza). Para un cambio global, editar el bloque `:root`.
 - **HTML para email**: muchos clientes email rompen estilos. Si destino es email, simplificar (pocos colores, sin gradient en CTA, tipografía estándar) y avisar al usuario.
 
 ## Notas de diseño
 
 - **Móvil-first**: el HTML se ve más en móviles (compartido por WhatsApp) que en desktop. Probar legibilidad en pantalla 360px ancho.
 - **Sin JS**: aplicaciones de mensajería NO ejecutan JS. Si necesitas interactividad (toggle, accordion), usa `<details>` y `<summary>` (HTML semántico, funciona sin JS).
-- **Paleta iAmasters**: naranja `#ff8c42` (acento principal), morado `#b794f4` (citas/secundario), gris `#fafafa` (fondo). Coherente con README badges.
 - **Sin tracking**: no embebas Google Analytics ni similares. El HTML es del usuario.
+
+## Paleta de marca — Juan Camilo Paris
+
+Identidad visual por defecto de todos los HTML. Dirección: **azul confianza sobrio**, modo claro. Casa credibilidad clínica con un toque cálido mínimo (sin caer en lo corporativo frío ni en lo estridente). Definida como variables CSS en `:root` — cambiar ahí actualiza todo el documento.
+
+| Token | Hex | Rol | Uso |
+|---|---|---|---|
+| `--primary` | `#1D4E89` | Azul confianza (principal) | Bordes de hero/h2, h3, enlaces, valor de métricas, base del CTA |
+| `--accent` | `#4FB0C6` | Celeste (acento) | Borde de citas, borde inferior de cabeceras de tabla, fin del degradado CTA |
+| `--warm` | `#F2A65A` | Ámbar (toque cálido) | Solo como acento puntual (borde izq. de `metric-card`). Úsalo con moderación: es el guiño de calidez paisa, no el protagonista |
+| `--ink` | `#16202B` | Tinta | Texto principal |
+| `--muted` | `#5A6675` | Gris | Metadatos, texto secundario, footer |
+| `--bg` | `#F5F8FC` | Fondo | Página |
+| `--panel` | `#FFFFFF` | Tarjeta | Contenedor |
+| `--line` | `#DDE6F0` | Borde | Separadores, bordes de tabla |
+
+**Reglas de uso:**
+- El **azul** manda; el **celeste** acompaña; el **ámbar** es solo un guiño (≤1 elemento por vista).
+- Modo **claro** por defecto. Si el usuario pide versión oscura, invertir `--bg`/`--panel`/`--ink` manteniendo `--primary`/`--accent`/`--warm`.
+- **Footer fijo**: `Generado por Dr. Juan Camilo Paris` (sin enlaces ni marca de terceros).
+- Para una pieza puntual con otra identidad (p. ej. un cliente), override de variables en ese HTML; no se cambia el default de la skill.

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,12 @@ YOUTUBE_API_KEY=
 # OpenAI (opcional): si usas Whisper API para transcripciones largas en lugar de mlx-whisper local
 OPENAI_API_KEY=
 
+# strategy-deep-research (opcional): prefijo de login del proxy universitario (EZProxy)
+# para leer artículos científicos de pago con tu acceso institucional.
+# Pega SOLO el prefijo (NO tu usuario/contraseña — eso vive en tu sesión de navegador).
+# Ejemplo: https://login.ezproxy.tuuniversidad.edu.co/login?url=
+UNIV_PROXY_LOGIN_PREFIX=
+
 # ============================================================
 # NO necesarias para Claude Code
 # ============================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ Lo que aporta este repo encima de Sinapsis:
 - `me.md`, `work.md`, `team.md`, `current-priorities.md`, `goals.md`
 - `learnings.md`, `decisions-log.md`
 
-**Skills curadas (`.claude/skills/`)** — 25 skills core (ver registry abajo).
+**Skills curadas (`.claude/skills/`)** — 26 skills core (ver registry abajo).
 
 **Niveles de proyecto**:
 1. **Single task** — pregunta directa. Output a `projects/<skill-name>/<fecha>-<titulo>/`.
@@ -126,7 +126,7 @@ Lo que aporta este repo encima de Sinapsis:
 
 ## Skills registry (v0.8.0)
 
-Capa 1 = 25 skills core + 2 opcionales (cognito, arnes).
+Capa 1 = 26 skills core + 2 opcionales (cognito, arnes).
 
 ### `_meta/` — sistema (10)
 
@@ -168,12 +168,13 @@ Capa 1 = 25 skills core + 2 opcionales (cognito, arnes).
 | `automation-n8n-to-claude` | Migra workflows n8n al ecosistema Claude |
 | `automation-n8n-builder` | Crea workflows n8n vía MCP `n8n-mcp` |
 
-### `strategy/` (2)
+### `strategy/` (3)
 
 | Skill | Descripción |
 |---|---|
 | `metodo-ias` | Método I.A.S. (Intención · Acción · Síntesis) anti-AI-brain-fry — diario + semanal (v0.7) |
-| `strategy-web-research` | Research con subagentes |
+| `strategy-web-research` | Research ligero con subagentes (lookups rápidos) |
+| `strategy-deep-research` | 🆕 Deep research iterativo: prioriza fuentes primarias/oficiales sobre blogs, modo médico con MCP PubMed + proxy universitario, citas verificables, reporte MD + HTML |
 
 ### `tools/` (4)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,13 +168,14 @@ Capa 1 = 26 skills core + 2 opcionales (cognito, arnes).
 | `automation-n8n-to-claude` | Migra workflows n8n al ecosistema Claude |
 | `automation-n8n-builder` | Crea workflows n8n vía MCP `n8n-mcp` |
 
-### `strategy/` (3)
+### `strategy/` (4)
 
 | Skill | Descripción |
 |---|---|
 | `metodo-ias` | Método I.A.S. (Intención · Acción · Síntesis) anti-AI-brain-fry — diario + semanal (v0.7) |
 | `strategy-web-research` | Research ligero con subagentes (lookups rápidos) |
 | `strategy-deep-research` | 🆕 Deep research iterativo: prioriza fuentes primarias/oficiales sobre blogs, modo médico con MCP PubMed + proxy universitario, citas verificables, reporte MD + HTML |
+| `strategy-prd-builder` | 🆕 Crea PRDs híbridos (documento de decisión + playbook de construcción estilo "paso a paso") para apps, SaaS, no-code o contenido. Buenas prácticas empotradas (Atlassian/Maze/Lenny's). Output MD revisable en bloc de notas + HTML opcional |
 
 ### `tools/` (4)
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Y desde dentro de Claude Code: `/install-status` te muestra el dashboard sin toc
 
 1. **Sinapsis v4.5 (engine)** — memoria persistente, instintos auto-aprendidos, skills on-demand. Vendoreado intacto del [repo de Luis Pitik](https://github.com/Luispitik/sinapsis).
 2. **Capa OS** — brand context (voice, positioning, ICP), agent context sectorizado (me, work, team, priorities, goals), proyectos estructurados, multi-cliente con templates por vertical.
-3. **Skills curadas** — 23 skills validadas para marketing, estrategia, automatización, tools, visualización y meta-pensamiento. Todas siguen patrón skill.md + references/ + scripts/. Skills oficiales de Anthropic (docx, xlsx, pdf, pptx) se instalan vía marketplace en el día 4 de `/aprende`.
+3. **Skills curadas** — 26 skills validadas para marketing, estrategia, automatización, tools, visualización y meta-pensamiento. Todas siguen patrón skill.md + references/ + scripts/. Skills oficiales de Anthropic (docx, xlsx, pdf, pptx) se instalan vía marketplace en el día 4 de `/aprende`.
 
 > 🌱 **Sistema vivo**: el catálogo crece con la comunidad. Cuando una skill nueva de IA Masters Academy demuestra valor en producción, entra al repo. Ver [`docs/skills-recommended.md`](docs/skills-recommended.md) para proponer una.
 
@@ -76,7 +76,7 @@ No requiere conocimientos de programación. Sí requiere paciencia para configur
 
 - ✅ Memoria que persiste entre sesiones (no más "explícame tu stack otra vez")
 - ✅ Tu primer entregable real generado por el sistema en los primeros 20 min (welcome-quick-win)
-- ✅ 23 skills curadas, instaladas, listas para activarse cuando hablas con Claude
+- ✅ 26 skills curadas, instaladas, listas para activarse cuando hablas con Claude
 - ✅ Brand context (voz, posicionamiento, ICP) generable en 30 minutos extra
 - ✅ Multi-cliente listo para escalar (4 templates de vertical incluidos)
 - ✅ Sistema de aprendizaje continuo: lo que repites se gradúa a regla
@@ -157,7 +157,8 @@ automation/                       🆕 Automatización y migración
 
 strategy/                         Investigación, estrategia y metodologías
 ├── metodo-ias                    🆕 Método I.A.S. (Intención · Acción · Síntesis) anti-AI-brain-fry (v0.7)
-└── strategy-web-research         Research profundo multi-fuente (LangChain)
+├── strategy-web-research         Research ligero multi-fuente (lookups rápidos)
+└── strategy-deep-research        🆕 Deep research iterativo: fuentes primarias, modo médico (PubMed + Vancouver), citas verificables, MD + HTML
 
 tools/                            Utilidades transversales
 ├── tool-firecrawl-scraper        Wrapper Firecrawl con fallback manual
@@ -186,7 +187,7 @@ iamasters-os/
 ├── .claude/
 │   ├── settings.json           # Hooks Sinapsis + permisos seguros por defecto
 │   ├── commands/               # Slash commands del OS
-│   └── skills/                 # 22 skills curadas por categoría
+│   └── skills/                 # 26 skills curadas por categoría
 │
 ├── brand-context/              # Tu marca: voice, positioning, ICP, assets
 ├── context/                    # Contexto sectorizado: me, work, team, priorities, goals

--- a/scripts/enviar-informe-whatsapp.sh
+++ b/scripts/enviar-informe-whatsapp.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# enviar-informe-whatsapp.sh <ruta-al-report.html>
+#
+# 1) Copia el HTML al repo de GitHub Pages con nombre fechado.
+# 2) Genera un PDF del HTML con Chrome headless (si Chrome está disponible).
+# 3) Regenera index.html apuntando al informe más reciente.
+# 4) Publica (commit + push) en el repo de Pages.
+# 5) Imprime los enlaces públicos (PUBLISHED_HTML / PUBLISHED_PDF).
+#
+# El ENVÍO por WhatsApp lo hace quien llama al script:
+#   - El agente Claude / la routine: WebFetch a https://api.callmebot.com/whatsapp.php
+#   - Automatización fuera de Claude: curl al mismo endpoint.
+# (No se hace aquí para respetar el bloqueo de curl dentro de Claude Code.)
+#
+# Config por entorno (con defaults):
+#   PAGES_DIR  (default ~/reportes-ia-medicina)
+#   PAGES_URL  (default https://juanparisma.github.io/reportes-ia-medicina)
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+HTML_IN="${1:?Uso: enviar-informe-whatsapp.sh <ruta-al-report.html>}"
+[ -f "$HTML_IN" ] || { echo "ERROR: no existe el HTML: $HTML_IN"; exit 1; }
+
+PAGES_DIR="${PAGES_DIR:-$HOME/reportes-ia-medicina}"
+PAGES_URL="${PAGES_URL:-https://juanparisma.github.io/reportes-ia-medicina}"
+STAMP="$(date +%Y-%m-%d)"
+SLUG="$STAMP-ia-medicina"
+
+[ -d "$PAGES_DIR/.git" ] || { echo "ERROR: no encuentro el repo de Pages en $PAGES_DIR"; exit 1; }
+
+# 1) Copiar HTML fechado
+cp -f "$HTML_IN" "$PAGES_DIR/$SLUG.html"
+
+# 2) PDF con Chrome headless (best-effort)
+CHROME=""
+for c in \
+  "/c/Program Files/Google/Chrome/Application/chrome.exe" \
+  "/c/Program Files (x86)/Google/Chrome/Application/chrome.exe" \
+  "${LOCALAPPDATA:-}/Google/Chrome/Application/chrome.exe" \
+  "$(command -v google-chrome 2>/dev/null || true)" \
+  "$(command -v chromium 2>/dev/null || true)"; do
+  if [ -n "$c" ] && [ -x "$c" ]; then CHROME="$c"; break; fi
+done
+
+PDF_OK=0
+if [ -n "$CHROME" ]; then
+  if command -v cygpath >/dev/null 2>&1; then
+    FILEURL="file:///$(cygpath -m "$HTML_IN")"
+    OUTPDF="$(cygpath -m "$PAGES_DIR/$SLUG.pdf")"
+  else
+    FILEURL="file://$HTML_IN"; OUTPDF="$PAGES_DIR/$SLUG.pdf"
+  fi
+  if "$CHROME" --headless=new --disable-gpu --no-pdf-header-footer \
+       --print-to-pdf="$OUTPDF" "$FILEURL" >/dev/null 2>&1; then
+    PDF_OK=1
+  fi
+fi
+[ "$PDF_OK" = 1 ] || echo "AVISO: no se generó PDF (Chrome no disponible o falló). Sigo solo con HTML."
+
+# 3) index.html -> redirige al más reciente
+cat > "$PAGES_DIR/index.html" <<HTML
+<!DOCTYPE html><html lang="es"><head><meta charset="UTF-8">
+<meta http-equiv="refresh" content="0; url=$SLUG.html">
+<title>Informes — IA en medicina</title></head>
+<body>Abriendo el informe más reciente… <a href="$SLUG.html">$SLUG.html</a></body></html>
+HTML
+
+# 4) Publicar
+cd "$PAGES_DIR"
+git add -A
+if git commit -m "report: $SLUG" >/dev/null 2>&1; then
+  git push origin main >/dev/null 2>&1 || { echo "ERROR: falló el push a Pages"; exit 1; }
+else
+  echo "Sin cambios que publicar (¿ya estaba el informe de hoy?)."
+fi
+
+# 5) Emitir enlaces
+echo "PUBLISHED_HTML=$PAGES_URL/$SLUG.html"
+[ "$PDF_OK" = 1 ] && echo "PUBLISHED_PDF=$PAGES_URL/$SLUG.pdf"
+echo "OK"


### PR DESCRIPTION
## Summary
- Nueva skill `strategy-deep-research`: investigación profunda iterativa que prioriza **fuentes primarias/oficiales** sobre blogs, con citas verificables.
- **Modo médico**: usa el MCP de PubMed como fuente primaria (texto completo open-access vía PMC; ruta de proxy universitario EZProxy para artículos de pago) y referencia en **estilo Vancouver**.
- **Modo web/general**: tabla de fuentes con URL abrible + fecha de acceso.
- Regla obligatoria de **expansión de siglas** (término completo + sigla en primera aparición + bloque de abreviaturas) para entendibilidad por terceros.
- Entregables: reporte Markdown citado + HTML autocontenido compartible.

## Contenido
- `SKILL.md` + `references/` (source-tiers, citation-format, medical-sources, subagent-brief, examples).
- Registrada en `CLAUDE.md` (strategy 2→3, core 25→26), árbol de skills en `README.md`, y `.env.example` (`UNIV_PROXY_LOGIN_PREFIX`).

## Test plan
- [x] Ejecución real en modo médico (anti-PD-1 en cáncer gástrico 1L según PD-L1 CPS): 9 fuentes Tier 0–1, citas Vancouver, conflicto entre ensayos caracterizado, MD + HTML generados.
- [ ] Validar ruta de subagentes paralelos con acceso al MCP de PubMed en investigaciones más anchas.
- [ ] Configurar `UNIV_PROXY_LOGIN_PREFIX` para probar recuperación de texto completo de pago vía Claude in Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)