### PR TITLE
fix(install): Windows/Git Bash (MSYS) path compatibility for installer + gate

### DIFF
--- a/scripts/_install-gate.sh
+++ b/scripts/_install-gate.sh
@@ -17,6 +17,16 @@ set +e  # Nunca queremos que un hook roto bloquee la sesión
 
 STATE_FILE="$HOME/.claude/skills/_install-state.json"
 
+# Windows / Git Bash (MSYS): $STATE_FILE es /c/Users/... y node lo interpreta
+# como C:\c\Users\... (inexistente) al interpolarlo dentro del string del heredoc.
+# cygpath -m lo traduce a C:/Users/... (mixed), que node sí entiende.
+# Sin esto, el hook caía al catch en CADA sesión con un falso "state corrupted".
+if [[ -n "$MSYSTEM" ]] && command -v cygpath >/dev/null 2>&1; then
+    WIN_STATE_FILE="$(cygpath -m "$STATE_FILE")"
+else
+    WIN_STATE_FILE="$STATE_FILE"
+fi
+
 # Si no tenemos node, no podemos parsear el state. Salimos silencioso.
 # (Si node no está, Sinapsis tampoco funciona, así que el OS está roto de todos modos.)
 if ! command -v node >/dev/null 2>&1; then
@@ -39,7 +49,7 @@ fi
 node <<NODE_EOF
 try {
   const fs = require('fs');
-  const s = JSON.parse(fs.readFileSync('$STATE_FILE', 'utf8'));
+  const s = JSON.parse(fs.readFileSync('$WIN_STATE_FILE', 'utf8'));
 
   const phases = s.phases || {};
   const required = Object.entries(phases).filter(([k, v]) => v.required === true);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,6 +46,19 @@ SKILLS_DIR="$CLAUDE_HOME/skills"
 STATE_FILE="$SKILLS_DIR/_install-state.json"
 STATE_TEMPLATE="$SCRIPT_DIR/_install-state.template.json"
 
+# ── Windows / Git Bash (MSYS) path compatibility ──
+# Bash MSYS define $HOME=/c/Users/<user>. Al interpolar esa ruta POSIX dentro
+# de un string JS/Python (node -e / python -c), el runtime la interpreta como
+# C:\c\Users\... (inexistente). cygpath -m la traduce a C:/Users/... (mixed),
+# que tanto Node como Python entienden en argumentos y dentro de strings.
+if [[ -n "$MSYSTEM" ]] && command -v cygpath >/dev/null 2>&1; then
+    _win_path() { cygpath -m "$1"; }
+    WIN_STATE_FILE="$(cygpath -m "$STATE_FILE")"
+else
+    _win_path() { echo "$1"; }
+    WIN_STATE_FILE="$STATE_FILE"
+fi
+
 # ── Flags ──
 RESUME=false
 FORCE_REINSTALL=false
@@ -71,7 +84,18 @@ echo ""
 
 JSON_RUNTIME=""
 detect_json_runtime() {
-    if command -v node >/dev/null 2>&1; then
+    # En MSYS/Git Bash (Windows), node malinterpreta rutas POSIX — preferimos Python.
+    if [[ -n "$MSYSTEM" ]]; then
+        if command -v python3 >/dev/null 2>&1; then
+            JSON_RUNTIME="python3"
+        elif command -v python >/dev/null 2>&1 && python --version 2>&1 | grep -q "Python 3"; then
+            JSON_RUNTIME="python"
+        elif command -v node >/dev/null 2>&1; then
+            JSON_RUNTIME="node"
+        else
+            return 1
+        fi
+    elif command -v node >/dev/null 2>&1; then
         JSON_RUNTIME="node"
     elif command -v python3 >/dev/null 2>&1; then
         JSON_RUNTIME="python3"
@@ -84,12 +108,13 @@ detect_json_runtime() {
 
 json_validate() {
     # $1 = path to JSON file
+    local _p; _p="$(_win_path "$1")"
     case "$JSON_RUNTIME" in
         node)
-            node -e "JSON.parse(require('fs').readFileSync('$1','utf8'))" 2>/dev/null
+            node -e "JSON.parse(require('fs').readFileSync('$_p','utf8'))" 2>/dev/null
             ;;
         python3|python)
-            "$JSON_RUNTIME" -c "import json; json.load(open('$1'))" 2>/dev/null
+            "$JSON_RUNTIME" -c "import json; json.load(open('$_p'))" 2>/dev/null
             ;;
     esac
 }
@@ -104,7 +129,7 @@ json_set_phase() {
         node)
             node -e "
                 const fs = require('fs');
-                const f = '$STATE_FILE';
+                const f = '$WIN_STATE_FILE';
                 const s = JSON.parse(fs.readFileSync(f, 'utf8'));
                 if (!s.phases['$phase']) s.phases['$phase'] = {};
                 s.phases['$phase']['$field'] = $value;
@@ -113,13 +138,13 @@ json_set_phase() {
             "
             ;;
         python3|python)
-            "$JSON_RUNTIME" -c "
-import json, datetime
-f = '$STATE_FILE'
+            IAMASTERS_VAL="$value" "$JSON_RUNTIME" -c "
+import json, os, datetime
+f = '$WIN_STATE_FILE'
 s = json.load(open(f))
 s['phases'].setdefault('$phase', {})
-s['phases']['$phase']['$field'] = $value
-s['lastUpdatedAt'] = datetime.datetime.utcnow().isoformat() + 'Z'
+s['phases']['$phase']['$field'] = json.loads(os.environ['IAMASTERS_VAL'])
+s['lastUpdatedAt'] = datetime.datetime.now(datetime.timezone.utc).isoformat()
 json.dump(s, open(f, 'w'), indent=2)
 "
             ;;
@@ -132,7 +157,7 @@ json_set_root() {
         node)
             node -e "
                 const fs = require('fs');
-                const f = '$STATE_FILE';
+                const f = '$WIN_STATE_FILE';
                 const s = JSON.parse(fs.readFileSync(f, 'utf8'));
                 s['$1'] = $2;
                 s.lastUpdatedAt = new Date().toISOString();
@@ -140,12 +165,12 @@ json_set_root() {
             "
             ;;
         python3|python)
-            "$JSON_RUNTIME" -c "
-import json, datetime
-f = '$STATE_FILE'
+            IAMASTERS_VAL="$2" "$JSON_RUNTIME" -c "
+import json, os, datetime
+f = '$WIN_STATE_FILE'
 s = json.load(open(f))
-s['$1'] = $2
-s['lastUpdatedAt'] = datetime.datetime.utcnow().isoformat() + 'Z'
+s['$1'] = json.loads(os.environ['IAMASTERS_VAL'])
+s['lastUpdatedAt'] = datetime.datetime.now(datetime.timezone.utc).isoformat()
 json.dump(s, open(f, 'w'), indent=2)
 "
             ;;
@@ -157,14 +182,14 @@ json_get_phase_status() {
     case "$JSON_RUNTIME" in
         node)
             node -e "
-                const s = JSON.parse(require('fs').readFileSync('$STATE_FILE','utf8'));
+                const s = JSON.parse(require('fs').readFileSync('$WIN_STATE_FILE','utf8'));
                 console.log(s.phases['$1'] && s.phases['$1'].status || 'pending');
             "
             ;;
         python3|python)
             "$JSON_RUNTIME" -c "
 import json
-s = json.load(open('$STATE_FILE'))
+s = json.load(open('$WIN_STATE_FILE'))
 print(s['phases'].get('$1', {}).get('status', 'pending'))
 "
             ;;
@@ -177,7 +202,7 @@ json_push_error() {
         node)
             node -e "
                 const fs = require('fs');
-                const f = '$STATE_FILE';
+                const f = '$WIN_STATE_FILE';
                 const s = JSON.parse(fs.readFileSync(f, 'utf8'));
                 s.errors.push({ phase: '$1', message: \`$2\`, at: new Date().toISOString() });
                 s.lastUpdatedAt = new Date().toISOString();
@@ -187,10 +212,10 @@ json_push_error() {
         python3|python)
             "$JSON_RUNTIME" -c "
 import json, datetime
-f = '$STATE_FILE'
+f = '$WIN_STATE_FILE'
 s = json.load(open(f))
-s['errors'].append({'phase': '$1', 'message': '''$2''', 'at': datetime.datetime.utcnow().isoformat() + 'Z'})
-s['lastUpdatedAt'] = datetime.datetime.utcnow().isoformat() + 'Z'
+s['errors'].append({'phase': '$1', 'message': '''$2''', 'at': datetime.datetime.now(datetime.timezone.utc).isoformat()})
+s['lastUpdatedAt'] = datetime.datetime.now(datetime.timezone.utc).isoformat()
 json.dump(s, open(f, 'w'), indent=2)
 "
             ;;
@@ -207,7 +232,7 @@ mark_phase_done() {
         node)
             node -e "
                 const fs = require('fs');
-                const f = '$STATE_FILE';
+                const f = '$WIN_STATE_FILE';
                 const s = JSON.parse(fs.readFileSync(f, 'utf8'));
                 if (!s.completedPhases.includes('$1')) s.completedPhases.push('$1');
                 fs.writeFileSync(f, JSON.stringify(s, null, 2));
@@ -216,7 +241,7 @@ mark_phase_done() {
         python3|python)
             "$JSON_RUNTIME" -c "
 import json
-f = '$STATE_FILE'
+f = '$WIN_STATE_FILE'
 s = json.load(open(f))
 if '$1' not in s['completedPhases']:
     s['completedPhases'].append('$1')
@@ -760,7 +785,7 @@ main() {
     case "$JSON_RUNTIME" in
         node)
             node -e "
-const s = JSON.parse(require('fs').readFileSync('$STATE_FILE','utf8'));
+const s = JSON.parse(require('fs').readFileSync('$WIN_STATE_FILE','utf8'));
 for (const [k, v] of Object.entries(s.phases)) {
   const icon = v.status === 'done' ? '✅' : v.status === 'failed' ? '❌' : v.status === 'in-progress' ? '🟡' : '⏳';
   console.log('   ' + icon + ' ' + k + ' · ' + v.status);
@@ -770,7 +795,7 @@ for (const [k, v] of Object.entries(s.phases)) {
         python3|python)
             "$JSON_RUNTIME" -c "
 import json
-s = json.load(open('$STATE_FILE'))
+s = json.load(open('$WIN_STATE_FILE'))
 icons = {'done':'OK','failed':'ERR','in-progress':'WIP','pending':'...','skipped':'SKIP'}
 for k, v in s['phases'].items():
     print('   [' + icons.get(v.get('status','pending'),'?') + '] ' + k + ' . ' + v.get('status','pending'))


### PR DESCRIPTION
## Problema

En Windows + Git Bash (MSYS), `$HOME` vale `/c/Users/<user>`. Cuando esa ruta POSIX se interpola dentro de un string de `node -e` / `python -c`, el runtime la lee como `C:\c\Users\...` (inexistente) → fallan las lecturas/escrituras del state file.

Dos síntomas (descritos en #3):
1. La validación profunda de `install.sh` siempre falla bajo Git Bash → fuerza reinstalaciones innecesarias de Sinapsis.
2. **`_install-gate.sh` inyecta un falso `[INSTALL GATE] state corrupted ... run --force-reinstall` en CADA SessionStart** aunque la instalación esté perfecta. Ruido constante que empuja al usuario a un reinstall innecesario.

## Solución

**`scripts/install.sh`**
- Detecta MSYS y traduce la ruta del state file con `cygpath -m` (mixed mode `C:/Users/...`), que Node y Python entienden tanto en argumentos como dentro de strings.
- Bajo MSYS prefiere Python sobre Node como JSON runtime (Node es el que rompe).
- Pasa los valores JSON a Python vía env var `IAMASTERS_VAL` + `json.loads()`, evitando `SyntaxError` cuando el valor es un booleano u objeto.
- Reemplaza el deprecado `datetime.utcnow()` por `datetime.now(timezone.utc)` en **todas** las funciones.

**`scripts/_install-gate.sh`**
- Traduce la ruta del state file antes del heredoc de `node`. Fin del falso "state corrupted" en cada sesión bajo Git Bash.

## Verificación

- `bash -n` OK en ambos scripts.
- Escritura de valor booleano vía env var → OK (antes petaba con `SyntaxError`).
- Gate sale silencioso (exit 0, sin output) cuando todas las fases `required` están `done`.
- `now(timezone.utc)` produce ISO válido.
- Cero regresión en mac/Linux: el fix solo se activa si `$MSYSTEM` está definido.

⚠️ Pendiente: validación en un Windows + Git Bash real (no disponible en el entorno de desarrollo).

---

Closes #3. Supersedes #1 (de @gguardiola1jyaa-commits) — rebaseado sobre el `main` actual y **extendido al `_install-gate.sh`**, que el #1 no cubría. Crédito a @gguardiola1jyaa-commits como co-autor del commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)