### PR TITLE
fix(skills): intent triggers + gitignore synapsis/

### DIFF
--- a/.claude/skills/marketing/marketing-brand-voice/SKILL.md
+++ b/.claude/skills/marketing/marketing-brand-voice/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: marketing-brand-voice
 version: 2.0.0
-description: Genera el voice profile completo del operador con 3 registros (A formal, B divulgativo, C cercano). Mecánica de doble ruta (artefactos reales o simulación guiada) que captura voz auténtica incluso si el operador no tiene presencia online. Combina interview directa + Firecrawl scraping de URLs públicas + 5 simulaciones por registro. Output a brand-context/voice/ con 8 archivos: voice-profile.md, samples.md, register-{a,b,c}.md, audit-prompt.md, vocabulary.md, installation.md. Lo invoca el onboarding wizard tras la identidad.
+description: Genera el voice profile completo del operador con 3 registros (A formal, B divulgativo, C cercano). Úsala cuando el usuario diga o pida "trabaja mi voz de marca", "define mi tono", "brand voice", "cómo sueno", "mi estilo de escritura", "perfil de voz", o quiera capturar/refinar cómo escribe. Mecánica de doble ruta (artefactos reales o simulación guiada) que captura voz auténtica incluso si el operador no tiene presencia online. Combina interview directa + Firecrawl scraping de URLs públicas + 5 simulaciones por registro. Output a brand-context/voice/ con 8 archivos: voice-profile.md, samples.md, register-{a,b,c}.md, audit-prompt.md, vocabulary.md, installation.md. También la invoca el onboarding wizard tras la identidad.
 ---
 
 # marketing-brand-voice · v2.0

--- a/.claude/skills/marketing/marketing-icp/SKILL.md
+++ b/.claude/skills/marketing/marketing-icp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: marketing-icp
-description: Define el Ideal Customer Profile en detalle: dolor exacto, lenguaje que usa, buying triggers, anti-ICP. Combina interview con análisis de competidores (qué clientes tienen) y de testimonios reales del operador. Output a brand-context/icp/icp.md. Se invoca después de positioning o cuando el operador no sabe a quién venderle.
+description: Define el Ideal Customer Profile en detalle: dolor exacto, lenguaje que usa, buying triggers, anti-ICP. Úsala cuando el usuario diga o pida "a quién le vendo", "cliente ideal", "ICP", "mi público objetivo", "perfil de cliente", "buyer persona", o no tenga claro a quién dirigirse. Combina interview con análisis de competidores (qué clientes tienen) y de testimonios reales del operador. Output a brand-context/icp/icp.md. También se invoca después de positioning.
 ---
 
 # marketing-icp

--- a/.claude/skills/marketing/marketing-positioning/SKILL.md
+++ b/.claude/skills/marketing/marketing-positioning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: marketing-positioning
-description: Construye o refina el posicionamiento del operador. Analiza competidores (con tool-firecrawl-scraper), identifica hueco de mercado, propone 3-5 ángulos de posicionamiento y deja al operador elegir. Output a brand-context/positioning/positioning.md. Se invoca tras brand-voice o cuando el operador siente que el mensaje no diferencia.
+description: Construye o refina el posicionamiento del operador. Úsala cuando el usuario diga o pida "posicionamiento", "cómo me diferencio", "qué me hace distinto", "mi mensaje no diferencia", "ángulo de posicionamiento", "propuesta de valor", o sienta que suena igual que la competencia. Analiza competidores (con tool-firecrawl-scraper), identifica hueco de mercado, propone 3-5 ángulos de posicionamiento y deja al operador elegir. Output a brand-context/positioning/positioning.md. También se invoca tras brand-voice.
 ---
 
 # marketing-positioning

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ context/learnings.md
 context/soul.md
 context/working-memory.md
 context/loops-config.md
+synapsis/
 brand-context/voice/voice-profile.md
 brand-context/voice/samples.md
 brand-context/voice/vocabulary.md

--- a/skills-library/marketing/marketing-content-repurposing/SKILL.md
+++ b/skills-library/marketing/marketing-content-repurposing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: marketing-content-repurposing
-description: Convierte una pieza fuente (video YouTube, podcast, transcript reunión, blog largo) en 5-8 piezas multiplataforma respetando brand voice. Output paquete con LinkedIn post + X thread + email newsletter + Instagram caption + clips ideas + headlines blog. Invoca marketing-copywriting por cada pieza y tool-output-verifier como gate.
+description: Convierte una pieza fuente (video YouTube, podcast, transcript reunión, blog largo) en 5-8 piezas multiplataforma respetando brand voice. Úsala cuando el usuario diga o pida "convierte este vídeo/podcast/transcript/post en piezas", "repurposing", "saca contenido de…", "distribuye esto en varias plataformas", "trocea esto para redes", o aporte una pieza larga para reaprovechar. Output paquete con LinkedIn post + X thread + email newsletter + Instagram caption + clips ideas + headlines blog. Invoca marketing-copywriting por cada pieza y tool-output-verifier como gate.
 ---
 
 # marketing-content-repurposing

--- a/skills-library/marketing/marketing-copywriting/SKILL.md
+++ b/skills-library/marketing/marketing-copywriting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: marketing-copywriting
-description: Genera copy para una plataforma específica (LinkedIn post, X thread, email, landing section, ad) usando brand-voice y registers A/B/C automáticamente. Pasa por tool-output-verifier obligatoriamente antes de entregar. Devuelve 1-3 variaciones para que el operador elija. La skill estrella del módulo marketing.
+description: Genera copy para una plataforma específica (LinkedIn post, X thread, email, landing section, ad) usando brand-voice y registers A/B/C automáticamente. Úsala cuando el usuario diga o pida "escríbeme/redacta/hazme un post de LinkedIn", "un tweet" o "un hilo de X", "un email", "un anuncio", "una sección de landing", "un headline", "copy para…", o pida cualquier texto de marketing para una plataforma. Pasa por tool-output-verifier obligatoriamente antes de entregar. Devuelve 1-3 variaciones para que el operador elija. La skill estrella del módulo marketing.
 ---
 
 # marketing-copywriting


### PR DESCRIPTION
## Cambios
- Anade intent triggers a las 5 skills de marketing (brand-voice, positioning, icp, copywriting, content-repurposing) para que el router las dispare correctamente
- .gitignore: excluye synapsis/ local (daily summaries personales, no van al repo)

## Notas
- Rebasado sobre main (v0.10.1) sin perdida de contenido
- copywriting y content-repurposing se movieron a skills-library/ en v0.10.0 — los triggers se aplicaron correctamente en la nueva ubicacion