### PR TITLE
fix(skills): self-healing catalog — regenerate skills-catalog.json from disk

### DIFF
--- a/scripts/regen-catalog.mjs
+++ b/scripts/regen-catalog.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// ============================================================
+//  iAmasters OS — regen-catalog.mjs
+//  Regenera synapsis/skills-catalog.json DESDE EL DISCO (única
+//  fuente de verdad). Lo invoca scripts/skills.sh tras add/remove/sync
+//  (y el subcomando `catalog`), de modo que el catálogo nunca deriva.
+//
+//  status por skill:
+//    - "core"      → instalada en .claude/skills/ y SIN copia en la biblioteca
+//    - "installed" → instalada en .claude/skills/ y también en la biblioteca
+//    - "library"   → solo en skills-library/ (no instalada, coste cero)
+//
+//  También pone .claude/.skills-pending.json a pending:false (drift resuelto).
+// ============================================================
+import { readFileSync, writeFileSync, readdirSync, existsSync, statSync, mkdirSync } from "node:fs";
+import { join, dirname, basename, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const INST_DIR = join(REPO_ROOT, ".claude", "skills");
+const LIB_DIR = join(REPO_ROOT, "skills-library");
+const OUT = join(REPO_ROOT, "synapsis", "skills-catalog.json");
+const PENDING = join(REPO_ROOT, ".claude", ".skills-pending.json");
+const quiet = process.argv.includes("--quiet");
+
+// --- minimal YAML frontmatter extractor (name / description / version) ---
+function parseFrontmatter(md) {
+  md = md.replace(/\r\n?/g, "\n"); // normalizar CRLF/CR → LF (`.` no matchea \r en regex JS)
+  if (!md.startsWith("---")) return {};
+  const end = md.indexOf("\n---", 3);
+  if (end === -1) return {};
+  const block = md.slice(3, end).replace(/^\n/, "");
+  const lines = block.split("\n");
+  const out = {};
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+    if (!m) continue;
+    const key = m[1];
+    let val = m[2];
+    // folded/literal block scalar (> or |) or empty → gather more-indented lines
+    if (val === ">" || val === "|" || val === ">-" || val === "|-" || val === "") {
+      const parts = [];
+      let j = i + 1;
+      for (; j < lines.length; j++) {
+        if (/^\s+\S/.test(lines[j]) || lines[j].trim() === "") parts.push(lines[j].trim());
+        else break;
+      }
+      val = parts.join(" ").trim();
+      i = j - 1;
+    }
+    // strip surrounding quotes
+    val = val.replace(/^["']|["']$/g, "").trim();
+    if (key === "name" || key === "description" || key === "version") out[key] = val;
+  }
+  return out;
+}
+
+// --- scan a root two levels deep: <root>/<category>/<skill>/SKILL.md ---
+function scan(root) {
+  const found = [];
+  if (!existsSync(root)) return found;
+  for (const category of readdirSync(root)) {
+    const catDir = join(root, category);
+    let st;
+    try { st = statSync(catDir); } catch { continue; }
+    if (!st.isDirectory()) continue;
+    for (const name of readdirSync(catDir)) {
+      if (name.startsWith("_archived")) continue;
+      const skillDir = join(catDir, name);
+      const skillFile = join(skillDir, "SKILL.md");
+      if (!existsSync(skillFile)) continue;
+      const fm = parseFrontmatter(readFileSync(skillFile, "utf8"));
+      const desc = (fm.description || "").replace(/\s+/g, " ").trim().slice(0, 220);
+      found.push({
+        name, category,
+        path: relative(REPO_ROOT, skillDir).split("\\").join("/"),
+        description: desc,
+        version: fm.version || null,
+      });
+    }
+  }
+  return found;
+}
+
+const installed = scan(INST_DIR);
+const library = scan(LIB_DIR);
+const libNames = new Set(library.map((s) => s.name));
+const instNames = new Set(installed.map((s) => s.name));
+
+// Build the merged catalog. Installed entries win (their path is the live one).
+const byName = new Map();
+for (const s of installed) {
+  byName.set(s.name, { ...s, status: libNames.has(s.name) ? "installed" : "core" });
+}
+for (const s of library) {
+  if (instNames.has(s.name)) continue; // already represented by its installed copy
+  byName.set(s.name, { ...s, status: "library" });
+}
+
+const skills = [...byName.values()].sort(
+  (a, b) => a.category.localeCompare(b.category) || a.name.localeCompare(b.name)
+);
+
+const catalog = {
+  version: "0.9.0",
+  updated_at: new Date().toISOString(),
+  count: skills.length,
+  generated_by: "scripts/regen-catalog.mjs",
+  note: "Regenerado desde el disco por skills.sh (add/remove/sync/catalog). NO editar a mano.",
+  skills,
+};
+
+mkdirSync(dirname(OUT), { recursive: true });    // synapsis/ puede no existir en un checkout limpio
+writeFileSync(OUT, JSON.stringify(catalog, null, 2) + "\n");
+mkdirSync(dirname(PENDING), { recursive: true });
+writeFileSync(
+  PENDING,
+  JSON.stringify({ pending: false, skill_count: skills.length, synced_at: catalog.updated_at }, null, 2) + "\n"
+);
+
+if (!quiet) {
+  const core = skills.filter((s) => s.status === "core").length;
+  const inst = skills.filter((s) => s.status === "installed").length;
+  const lib = skills.filter((s) => s.status === "library").length;
+  console.log(`catálogo regenerado: ${skills.length} skills (core ${core} · biblioteca-instaladas ${inst} · biblioteca ${lib})`);
+}

--- a/scripts/skills.sh
+++ b/scripts/skills.sh
@@ -12,6 +12,9 @@
 #    bash scripts/skills.sh add <nombre>      # instala desde la biblioteca (+ deps)
 #    bash scripts/skills.sh remove <nombre>   # desinstala (las core no se pueden)
 #    bash scripts/skills.sh sync [--quiet]    # refresca instaladas tras /actualiza
+#    bash scripts/skills.sh catalog           # regenera el catálogo desde el disco
+#
+#  add/remove/sync regeneran synapsis/skills-catalog.json solos (sin drift).
 #
 #  Las personalizaciones del operador (SKILL.local.md) se preservan
 #  SIEMPRE: al instalar, desinstalar, reinstalar y sincronizar.
@@ -63,6 +66,21 @@ deps_for() {
 }
 
 say() { $QUIET || printf "%b\n" "$1"; }
+
+regen_catalog() {
+    # Regenera synapsis/skills-catalog.json desde el disco (fuente de verdad).
+    # Evita el drift: se llama tras cada add/remove/sync. No falla el comando
+    # si node no está disponible.
+    if command -v node >/dev/null 2>&1; then
+        if $QUIET; then
+            node "$REPO_ROOT/scripts/regen-catalog.mjs" --quiet >/dev/null 2>&1 || true
+        else
+            node "$REPO_ROOT/scripts/regen-catalog.mjs" || say "${YELLOW}  ! no se pudo regenerar el catálogo${NC}"
+        fi
+    else
+        say "${YELLOW}  ! node no disponible: catálogo no regenerado (corre 'skills.sh catalog' luego)${NC}"
+    fi
+}
 
 do_add() {
     local name="$1" as_dep="${2:-}"
@@ -208,6 +226,7 @@ case "$CMD" in
             exit 1
         fi
         do_add "$1"
+        regen_catalog
         say ""
         say "  Reinicia Claude Code para que cargue la skill."
         ;;
@@ -217,11 +236,13 @@ case "$CMD" in
             exit 1
         fi
         do_remove "$1"
+        regen_catalog
         ;;
-    sync)   do_sync ;;
+    sync)   do_sync; regen_catalog ;;
+    catalog) regen_catalog ;;
     -h|--help|help) grep '^#' "$0" | sed 's/^# \{0,2\}//' | head -18 ;;
     *)
-        printf "%b\n" "${RED}Comando desconocido: $CMD${NC} (usa list, add, remove o sync)"
+        printf "%b\n" "${RED}Comando desconocido: $CMD${NC} (usa list, add, remove, sync o catalog)"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Problema
`scripts/skills.sh` (`add`/`remove`/`sync`) modifica el filesystem pero **nunca actualiza** `synapsis/skills-catalog.json`. Resultado: el catálogo **deriva en cada instalación**, y las skills que lo leen (`meta-start-here`, `meta-wrap-up`, `meta-skill-creator`, el comando `install-skill`) trabajan con datos obsoletos: skills instaladas ausentes del catálogo, entradas mal etiquetadas `library`/`installed`, y un `.skills-pending.json` colgado en `pending:true`.

## Solución — el filesystem es la única fuente de verdad
El catálogo se **regenera desde el disco**, nunca se parchea a mano.

- **Nuevo `scripts/regen-catalog.mjs`** (Node, sin dependencias): escanea `.claude/skills/` + `skills-library/`, parsea el frontmatter de cada `SKILL.md`, deriva `status` (`core` | `installed` | `library`), y escribe `synapsis/skills-catalog.json` + limpia `.claude/.skills-pending.json`.
  - Robusto: normaliza frontmatter CRLF (en regex JS `.` no matchea `\r`) y crea `synapsis/` si no existe (funciona en un checkout limpio).
- **`scripts/skills.sh`**: llama a `regen_catalog()` tras `add`/`remove`/`sync` + nuevo subcomando `catalog`. Así el catálogo **ya no puede derivar** — cada operación lo auto-repara. No-op si `node` no está disponible.

## Verificación
- `bash scripts/skills.sh catalog` regenera el catálogo; 0 entradas sin `path`/`description`.
- Round-trip `add`/`remove` de una skill cambia su `status` `installed`↔`library` en el catálogo automáticamente.
- Probado en un checkout limpio de `main` (crea `synapsis/` y cataloga las 37 skills del árbol).

## Notas
- Solo toca `scripts/`. Los artefactos generados (`synapsis/skills-catalog.json`, `.claude/.skills-pending.json`) siguen gitignored.
- Cambio aditivo y de bajo riesgo: si `node` falta, los comandos siguen funcionando igual que antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)