### PR TITLE
feat(skills): add conclave dev loop + fused pre-commit gate

### DIFF
--- a/.claude/skills/engineering/conclave/SKILL.md
+++ b/.claude/skills/engineering/conclave/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: conclave
+description: Metodología de desarrollo multi-agente — un modelo de mayor capacidad planifica y diseña (código + pruebas), agentes de ejecución codifican en paralelo (fan-out) y un revisor adversarial (abogado del diablo) hace de gate antes de CADA commit. Sin doble OK, no hay commit. USAR cuando construyas una feature, bug o fix con agentes de IA y quieras verificar el código, cazar bugs y elevar la calidad y la fiabilidad de forma continuada. Versión OS: delega la revisión en cognito/code-review/verify/security-review y el fan-out en Workflow/Agent.
+---
+
+# Cónclave — Multi-Agent Dev Loop
+
+> Los agentes construyen en paralelo y un revisor hace de **abogado del diablo**
+> hasta que hay consenso (doble OK) antes de cada commit.
+
+> **Versión iAmasters OS.** Adaptada del paquete de FlowenUp (Arturo Soto). No
+> duplica el revisor adversarial: lo **delega** en skills existentes
+> (`cognito`, `code-review`, `verify`, `security-review`) y el fan-out en la
+> herramienta nativa `Workflow` / `Agent`. El aporte neto de Cónclave aquí es
+> **dos piezas que el OS no tenía**: (1) formalizar el bucle
+> plan→fan-out→gate→doble-OK→commit, y (2) el **enforcement por hook** que
+> fuerza el doble OK antes de commitear código.
+
+## Propósito (el norte — SIEMPRE)
+No es poner un candado antes del commit: es **verificar el código, detectar
+bugs y mejorar de forma continuada el desarrollo**, para aumentar la
+**calidad** del código generado y su **fiabilidad**. La revisión es análisis
+adversarial real que busca fallos genuinos y deja el código mejor que antes —
+nunca un "apto" de trámite.
+
+## Qué es
+**Un plano + dos mitades.** Primero, un modelo de **mayor capacidad** planifica
+y diseña el código **y las pruebas** y deja el trabajo servido. Luego
+**(1) Fan-out** (opcional) — agentes de **ejecución** codifican en paralelo
+sobre ese plano (el esfuerzo de cada uno escala con la complejidad de su
+sub-tarea). Y **(2) Cónclave** (incondicional) — un revisor adversarial
+delibera contra el código antes de CADA commit. Nada se commitea sin doble OK.
+
+## PASO 0 · INTERROGATORIO OBLIGATORIO AL INVOCAR (no saltar)
+Antes de construir nada, la skill **pregunta y confirma** con el usuario — no
+asumir:
+1. **¿Con qué agente(s) se hará la REVISIÓN (el gate)?** Presenta opciones y
+   espera respuesta. En este OS las opciones canónicas son:
+   - `cognito` (modo *devil's advocate* en planning + modo *auditor* en review)
+     para razonamiento adversarial estructurado.
+   - `code-review` (bugs + cleanups del diff) + `verify` (ejercitar el cambio
+     end-to-end) + `security-review` si toca seguridad — el combo de revisión
+     de código built-in.
+   - Ambos (cognito + code-review/verify) para cambios sensibles.
+   El usuario confirma. Si el cambio es trivial/bajo riesgo, uno basta.
+2. **Evalúa el riesgo del cambio y recomienda:** ¿toca dinero, identidad,
+   seguridad o datos personales? → revisor fuerte y/o doble. ¿Cambio
+   mecánico/bajo riesgo? → uno basta. La elección la confirma el usuario.
+3. **Valida que la petición está bien formada:** unidad de trabajo clara ·
+   criterio de "hecho" (qué tests/build deben pasar) · descomposición en
+   sub-tareas independientes si va a haber fan-out.
+
+No avanzar hasta tener (a) revisor(es) elegido(s) y (b) petición validada.
+
+## REGLA INCONDICIONAL · SIN DOBLE OK NO HAY COMMIT
+El cambio pasa SIEMPRE por el revisor elegido antes de commitear. Solo se
+commitea con **doble OK** (modelo constructor + revisor). Hallazgos ≥
+IMPORTANTE → corregir → **re-pasar por el revisor** (nunca self-review) → bucle
+hasta APTO. Nunca `--no-verify`, nunca saltarse el gate "porque es pequeño".
+
+## ENFORCEMENT POR HOOK (la skill propone, el hook obliga)
+La skill es comportamiento; el **hook `pre-commit`** es el candado que lo hace
+inviolable.
+- Tras el doble OK, el proceso sella el árbol staged:
+  `git write-tree > .conclave/pass` (o `bash
+  .claude/skills/engineering/conclave/scripts/conclave-approve.sh`).
+- El hook compara el árbol staged con el sello: coincide → commit + consume el
+  sello; no coincide → **aborta**.
+- Un `git add` posterior invalida el sello → obliga a re-revisar. Override
+  consciente: `CONCLAVE_OVERRIDE=1 git commit …`.
+- **Scope en este OS:** el hook **solo exige sello cuando el staged toca
+  código** (`.sh .mjs .js .ts .py .ps1` o rutas bajo `hooks/` `vendor/`
+  `scripts/`). Los commits de solo docs/skills/`.md`/`brand-context`/`context`
+  pasan sin sello — el gate adversarial brilla en código, no asfixia docs. Los
+  guards de **secretos** y **archivos grandes** (heredados de Arnes) siguen
+  activos SIEMPRE, con o sin sello.
+- Instalación del hook: ver `references/install.md`.
+
+## Proceso
+- **Paso 0 · Interrogatorio + validación** (arriba) — elegir revisor, validar
+  la petición y **evaluar la complejidad para dimensionar el equipo**.
+- **Paso 1 · Plan & diseño (modelo de mayor capacidad):** analiza la tarea,
+  **diseña el código Y las pruebas** y la descompone en N sub-tareas
+  independientes con criterio de "hecho". Ese plano es el **contexto
+  compartido** que recibe cada agente de ejecución → la ejecución va
+  "servida". Si el proyecto arranca de cero, considera `arnes` (scaffolding)
+  o `spec-kit` (desarrollo dirigido por spec) antes de picar código.
+- **Paso 2 · Fan-out — ejecución (opcional):** lanzar N agentes constructores
+  en paralelo. En este OS, usa la herramienta **`Workflow`** (pipeline:
+  cada sub-tarea fluye por sus stages; verify adversarial al final) o el tool
+  **`Agent`** (varios en un solo mensaje para concurrencia). Cada agente recibe
+  su trozo del plano + reglas del proyecto (TDD + seguridad + "no tocar más de
+  lo pedido") + criterio de "hecho". Devuelven diff + tests, **NO commitean**.
+  Si no hay partes independientes → construcción única (sin fan-out).
+- **Paso 3 · Integración:** recomponer diffs, resolver solapes (el plano común
+  arbitra), correr build completo + suite entera.
+- **Paso 4 · Cónclave (gate adversarial)** con el revisor elegido — **delega**:
+  pasa el diff por `code-review` (bugs + cleanups) + `verify` (end-to-end) +
+  `security-review` (si toca seguridad). Para razonamiento adversarial
+  multimodo, `cognito` (devil's advocate / auditor). Veredicto APTO o
+  hallazgos.
+- **Paso 5 · Iterar** hasta que constructor + revisor coincidan en APTO
+  (re-corriendo build + tests cada vuelta).
+- **Paso 6 · Commit:** solo con doble OK. Sellar
+  (`bash .claude/skills/engineering/conclave/scripts/conclave-approve.sh` o
+  `git write-tree > .conclave/pass`) y commitear. Conventional Commits. Sin
+  `--no-verify`.
+
+## Output
+Cambio commiteado + traza de calidad (revisor usado, qué cazó, cuántas vueltas).
+Reutilizable para enseñar y para auditoría.
+
+## Skills colaboradoras
+- `cognito` — razonamiento adversarial (devil's advocate, auditor).
+- `code-review` / `verify` / `security-review` (built-in) — revisión de código
+  del diff (bugs, end-to-end, seguridad).
+- `arnes` / `spec-kit` / `ask-questions-if-underspecified` — planificar y
+  arrancar de cero (Paso 1).
+- `tool-quality-gate` / `code-audit-integral` — gates pre-deploy más amplios
+  (no solo commit): build/env/tests/security con score.
+- `meta-wrap-up` — cierre de sesión; propone commit con aprobación blanda
+  (Cónclave es el candado duro para código).
+
+## Notas
+- Máx ~10-16 agentes concurrentes; diffs paralelos sobre el mismo fichero se
+  resuelven en integración (o worktree por agente si mutan en paralelo).
+- Si el revisor de código no responde en tu entorno, usa un fallback (otro
+  revisor) — nunca saltarte el gate.
+- El sello `.conclave/pass` es local al working tree (ignorado por git); no
+  viaja entre máquinas ni sobrevive a `git clean`.

--- a/.claude/skills/engineering/conclave/references/install.md
+++ b/.claude/skills/engineering/conclave/references/install.md
@@ -1,0 +1,76 @@
+# Cónclave — instalación (versión iAmasters OS)
+
+> **Esta variante NO usa el `install.sh`/`install.ps1` original del paquete.**
+> El instalador original sobrescribe `.git/hooks/pre-commit` sin backup y
+> pisaría el hook **Arnes v0.2.4** (guard de secretos + archivos grandes) que
+> ya vive en este repo. Aquí el hook se **fusiona** a mano.
+
+## Qué se instaló en este OS
+
+```
+.claude/skills/engineering/conclave/
+├── SKILL.md                  ← la skill (adaptada: delega revisión en cognito/code-review/verify)
+├── scripts/
+│   └── conclave-approve.sh   ← sella el árbol tras el doble OK (one-liner envuelto)
+└── references/
+    └── install.md            ← esto
+```
+
+Más:
+- `hooks/pre-commit` ← **fusionado**: Arnes (secretos + archivos grandes,
+  SIEMPRE) + sello Cónclave (SOLO si el staged toca código).
+- `.git/hooks/pre-commit` ← copia activa de `hooks/pre-commit` (no commiteada).
+- `.gitignore` ← entrada `.conclave/` añadida.
+- Catálogo/registry regenerados: `conclave` aparece como skill core bajo
+  `engineering/`.
+
+## Cómo funciona el gate (el flujo real)
+
+1. Desarrollas con la skill (fan-out opcional + revisión adversarial delegada
+   en `cognito`/`code-review`/`verify`/`security-review`).
+2. Cuando el **constructor y el revisor dan APTO** (doble OK), sellas el árbol
+   staged:
+   ```bash
+   bash .claude/skills/engineering/conclave/scripts/conclave-approve.sh
+   # equivale a: git write-tree > .conclave/pass
+   ```
+3. `git commit` → el hook compara el árbol staged con el sello. Coincide →
+   commit (y consume el sello). No coincide → **aborta**.
+4. Cualquier `git add` posterior al sello lo invalida → obliga a re-revisar
+   (garantiza que se commitea EXACTAMENTE lo revisado).
+
+## Scope del gate en este OS
+
+El hook **solo exige sello cuando el staged toca código**:
+- Extensiones: `.sh .mjs .js .ts .py .ps1`
+- Rutas bajo: `hooks/`, `vendor/`, `scripts/`
+
+Los commits de **solo docs/skills/`.md`/`brand-context`/`context`/`projects`**
+pasan **sin sello** (el gate no asfixia docs). Los guards de **secretos**
+(`API_KEY|SECRET|PASSWORD|TOKEN`) y **archivos grandes (>1M)** son
+incondicionales: bloquean siempre, con o sin sello.
+
+## Override de emergencia (deja rastro, úsalo consciente)
+
+```bash
+CONCLAVE_OVERRIDE=1 git commit -m "..."
+```
+
+Bypassa **solo** el sello de Cónclave. **No** bypassa el guard de secretos ni
+el de archivos grandes — esos siguen bloqueando.
+
+## Re-aplicar el hook en otro repo (p. ej. un proyecto de software)
+
+Si quieres llevar el gate a un repo de software de verdad (FVI, Polymaster…):
+
+1. Copia la skill: `cp -r .claude/skills/engineering/conclave <destino>/.claude/skills/engineering/`
+2. Copia el hook: `cp hooks/pre-commit <destino>/.git/hooks/pre-commit && chmod +x <destino>/.git/hooks/pre-commit`
+3. Añade `.conclave/` al `.gitignore` del destino.
+
+> En un repo de software (no de skills), considera cambiar el scope del gate a
+> "todos los commits" (quitar el filtro por extensión) — ahí todo es código.
+
+## Requisitos
+- git. Bash disponible (Git Bash en Windows sirve). Un agente de IA (Claude
+  Code u otro) que ejecute la skill y un revisor (`cognito`/`code-review`/…
+  en este OS) para el gate.

--- a/.claude/skills/engineering/conclave/scripts/conclave-approve.sh
+++ b/.claude/skills/engineering/conclave/scripts/conclave-approve.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Cónclave · sellar el árbol staged tras el DOBLE OK.
+# Llamar SOLO cuando constructor + revisor han dado APTO. Después: git commit.
+set -euo pipefail
+mkdir -p .conclave
+git write-tree > .conclave/pass
+echo "✓ Conclave: sello escrito para el arbol staged actual. Ya puedes commitear."

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ desktop.ini
 # CodeGraph index local (si se usa el add-on)
 .codegraph/
 
+# Cónclave · gate pre-commit (sello local de doble OK tras revisión adversarial)
+.conclave/
+
 # Operator data — privado por usuario, no se commitea
 context/daily-memory/
 context/.memory-index/
@@ -61,6 +64,9 @@ projects/briefs/*
 projects/*/
 !projects/.gitkeep
 !projects/briefs/.gitkeep
+# Deploy artifacts sueltos en projects/ (p. ej. fvi-deploy-package.tar.gz, 680 MB)
+projects/*.tar.gz
+projects/*.zip
 # Excepción: el showcase sí forma parte del repo (material de referencia)
 !projects/_showcase/
 !projects/_showcase/**

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Pre-commit hook · Arnes + Cónclave (iAmasters OS)
+#
+# Bloque 1 (Arnes v0.2.4): secretos + archivos grandes — SIEMPRE, incondicional.
+# Bloque 2 (Cónclave):      sello de doble OK — SOLO si el staged toca código.
+#
+# Código = extensiones .sh .mjs .js .ts .py .ps1  o  rutas bajo hooks/ vendor/ scripts/
+# Los commits de solo docs/skills/.md pasan SIN sello (el gate no asfixia docs).
+# Override del sello (NO de los secretos):  CONCLAVE_OVERRIDE=1 git commit ...
+set -uo pipefail
+
+echo "🔍 Verificando commit..."
+
+# Staged files (excluye deletes y renames para no procesar rutas inexistentes/duales)
+STAGED="$(git diff --cached --name-only --diff-filter=d --no-renames)"
+
+# ─── Bloque 1a · Secretos (Arnes, incondicional) ────────────────────────────
+# Patrón afinado: requiere asignación ([:=]) tras la palabra clave, para no
+# autofalsear con la propia cadena del patrón ni con comentarios sueltos.
+LEAK=""
+if [ -n "$STAGED" ]; then
+  LEAK="$(printf '%s\n' "$STAGED" | xargs -r grep -IlE '(API_KEY|SECRET|PASSWORD|TOKEN)[[:space:]]*[:=]' 2>/dev/null || true)"
+fi
+if [ -n "$LEAK" ]; then
+  echo "❌ DETECTADO: posibles secretos en el commit:"
+  echo "$LEAK"
+  echo "Revisa los archivos antes de commitear (usa variables de entorno, no claves hardcodeadas)."
+  exit 1
+fi
+
+# ─── Bloque 1b · Archivos grandes (Arnes, incondicional, confirmación) ──────
+LARGE=""
+if [ -n "$STAGED" ]; then
+  LARGE="$(printf '%s\n' "$STAGED" | xargs -r du -k 2>/dev/null | awk '$1 >= 1024 {print $2}' || true)"
+fi
+if [ -n "$LARGE" ]; then
+  echo "⚠️  ADVERTENCIA: archivos grandes detectados (>1 MB):"
+  echo "$LARGE"
+  printf '¿Commitearlos igualmente? (s/N) '
+  read -r response
+  if [ "$response" != "s" ]; then
+    echo "Cancelado."
+    exit 1
+  fi
+fi
+
+# ─── Bloque 2 · Sello Cónclave (SOLO si el staged toca código) ──────────────
+CODE_PATTERN='\.(sh|mjs|js|ts|py|ps1)$|(^|/)(hooks|vendor|scripts)/'
+CODE_FILES=""
+if [ -n "$STAGED" ]; then
+  CODE_FILES="$(printf '%s\n' "$STAGED" | grep -E "$CODE_PATTERN" || true)"
+fi
+
+if [ -z "$CODE_FILES" ]; then
+  # Commit de solo docs/config/skills → no exige sello
+  echo "✅ Verificación completa (sin código staged: gate Cónclave skipped)."
+  exit 0
+fi
+
+STAMP=".conclave/pass"
+TREE="$(git write-tree)"
+
+if [ -f "$STAMP" ] && [ "$(cat "$STAMP" 2>/dev/null)" = "$TREE" ]; then
+  rm -f "$STAMP"   # sello de un solo uso
+  echo "✅ Verificación completa (sello Cónclave válido: código revisado)."
+  exit 0
+fi
+
+if [ "${CONCLAVE_OVERRIDE:-0}" = "1" ]; then
+  echo "⚠️  Conclave: OVERRIDE manual — commit de código permitido sin gate." >&2
+  exit 0
+fi
+
+cat >&2 <<'MSG'
+──────────────────────────────────────────────
+ ⛔  CONCLAVE · este cambio de CÓDIGO no ha pasado la revisión.
+     Ningún commit de código sin doble OK (constructor + revisor).
+       1. Pasa la revisión adversarial (cognito / code-review / verify).
+       2. Tras el doble OK:   git write-tree > .conclave/pass
+          (o: bash .claude/skills/engineering/conclave/scripts/conclave-approve.sh)
+       3. Vuelve a commitear.
+     Override consciente:   CONCLAVE_OVERRIDE=1 git commit ...
+──────────────────────────────────────────────
+MSG
+exit 1


### PR DESCRIPTION
## Qué

Adapta el paquete **Cónclave** de FlowenUp — metodología de desarrollo multi-agente: un modelo de mayor capacidad planifica/diseña → fan-out de agentes ejecutan → un revisor adversarial actúa como **gate OBLIGATORIO** antes de cada commit, enforcementado por un hook `pre-commit` con sello `git write-tree`. Sin doble OK, no hay commit.

## Triaje (no duplica lo existente)

- **~70% delega** en skills ya presentes: el revisor adversarial es `cognito` (modos devil's advocate + auditor); la review de código son `code-review`/`verify`/`security-review` + `tool-quality-gate`.
- **~30% es hueco real**: (1) formalizar el bucle plan → fan-out → gate → doble-OK → commit, y (2) el **enforcement por hook** que fuerza el doble OK antes de commitear código (no existía; el hook actual solo guardaba secretos).

## Cambios

- **Skill `engineering/conclave`**: formaliza el flujo y **delega** la revisión y el fan-out en skills/herramientas existentes (`cognito`, `code-review`/`verify`/`security-review`, `Workflow`/`Agent`).
- **`hooks/pre-commit` fusionado**: guard de secretos + archivos grandes (incondicional) + sello Cónclave (solo si el staged toca código: `.sh/.mjs/.js/.ts/.py/.ps1` o `hooks/`/`vendor/`/`scripts/`). Los commits de solo docs pasan sin sello.
- Patrón de secretos afinado (`[:=]` tras la palabra clave) para que el hook no se autobloquee con su propio patrón.
- `.conclave/` añadido al `.gitignore`.

## Verificación

6/6 tests pasados: docs pasan sin sello · código sin sello bloquea · código con sello pasa · idempotencia (sello de un solo uso) · override (`CONCLAVE_OVERRIDE=1`) · secretos bloquean siempre.

## Notas

- Este PR **no toca `CLAUDE.md`**: la sección de routing del OS vive en la rama de desarrollo `feat/nuevas-skills`; el routing de conclave se integra al mergear esa rama.
- Override de emergencia: `CONCLAVE_OVERRIDE=1 git commit …` (bypassa el sello, **no** los secretos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
