### PR TITLE
fix(install): cablear hooks de Sinapsis en settings.json existente + instalación sin terminal (v0.10.2)

### DIFF
--- a/.claude/commands/instala.md
+++ b/.claude/commands/instala.md
@@ -1,0 +1,61 @@
+---
+description: Instala iAmasters OS de principio a fin sin que el usuario toque la terminal. Punto de entrada en lenguaje natural — se dispara con "instala esto", "instálamelo", "install this", "monta el OS", "set this up" o "/instala". Detecta el SO, ejecuta el installer técnico (Sinapsis + capa OS), verifica y sigue con el onboarding. Mac y Windows (Git Bash).
+---
+
+# /instala
+
+El camino de instalación **más simple**: el usuario dice "instala esto" y tú te encargas de todo. No le mandes a abrir una terminal — lo ejecutas tú con la tool `Bash` (ya está permitido en `.claude/settings.json`).
+
+## Cuándo se dispara
+
+Además de `/instala`, dispara este flujo cuando el usuario diga (castellano o inglés):
+- "instala esto" · "instálamelo" · "instala el OS" · "monta el sistema" · "configúrame esto"
+- "install this" · "set this up" · "install the OS"
+- Pegue la URL del repo `iamasters-academy/iamasters-os` pidiendo instalarlo
+
+## Process
+
+### Paso 0 · Confirmar (una línea)
+
+> "Te instalo iAmasters OS ahora mismo (Sinapsis + capa OS, ~30s) y luego seguimos con tu setup. ¿Le doy?"
+
+Espera un "sí/vamos/ok". Si el usuario ya dijo "instala esto", eso ES el OK — no vuelvas a preguntar, arranca.
+
+### Paso 1 · Detectar entorno y ejecutar el installer
+
+1. Detecta el SO con `Bash`: `uname -s` (Darwin/Linux → Mac/Linux; MINGW/MSYS/CYGWIN → Windows con Git Bash).
+2. Ejecuta el installer técnico con la tool `Bash`:
+   ```bash
+   bash scripts/install.sh
+   ```
+   - Es **idempotente y reentrante**: si ya corrió antes, retoma solo lo pendiente. Si algo estaba `failed`, se puede relanzar sin miedo.
+   - **Windows**: corre igual vía Git Bash (Claude Code ya lo requiere). Si `uname` no existe / `bash` no está disponible para Claude Code → dile:
+     > "En Windows necesito Git Bash (viene con Git para Windows: https://git-scm.com/download/win). Instálalo y me dices, o abre una terminal Git Bash en esta carpeta y ejecuta `bash scripts/install.sh`."
+3. **Parsea la salida estructurada** línea a línea:
+   - `[OK] <fase>` → hecho
+   - `[SKIP] <fase>` → ya estaba
+   - `[WARN] <fase> · <motivo>` → siguió con limitación (menciónalo pero no bloquea)
+   - `[ERROR] <fase> · <motivo>` → **bloqueante**: para, explícalo en castellano, propón el arreglo (p.ej. instalar Node.js ≥18) y ofrece reintentar con `bash scripts/install.sh --resume`. No sigas al Paso 3.
+
+### Paso 2 · Verificar (sin fiarte del "parece que fue bien")
+
+Lee `~/.claude/skills/_install-state.json` y confirma que `phases.prereqs` y `phases.sinapsis-engine` están en `status: "done"`. Si `sinapsis-engine.validation` reporta `hooks` sin cablear o falta algún check, díselo y relanza `--resume`.
+
+> Nota: los hooks de Sinapsis solo se **activan al reiniciar** Claude Code (se enlazan en `SessionStart`). Aunque el install haya ido perfecto, el motor de aprendizaje entra en vigor en la **próxima** sesión. Avísale al final.
+
+### Paso 3 · Seguir con el onboarding
+
+Con las fases técnicas en `done`, continúa el flujo conversacional:
+1. Invoca `/install` (orquesta las fases restantes: context-files, operator-state, welcome).
+2. `/install` deriva al `meta-onboarding-wizard` para la entrevista por sub-fases.
+
+### Paso 4 · Cierre
+
+> "Listo. iAmasters OS instalado y validado ✅. Los hooks de Sinapsis se activan al reiniciar Claude Code. ¿Seguimos con tu onboarding ahora o lo dejamos para luego?"
+
+## Lo que NO haces
+
+- ❌ Mandar al usuario a la terminal por defecto (solo como fallback si `bash` no está en Windows)
+- ❌ Crear archivos en `~/.claude/skills/` a mano para simular instalación
+- ❌ Marcar fases como `done` tú mismo — de eso se encarga `install.sh`
+- ❌ Seguir al onboarding si quedó un `[ERROR]` sin resolver

--- a/.claude/commands/install.md
+++ b/.claude/commands/install.md
@@ -12,16 +12,13 @@ Coordinas la instalación por fases de iAmasters OS. La fuente de verdad es `~/.
 
 Lee `~/.claude/skills/_install-state.json` con la tool `Read`. Si NO existe:
 
-- Indica al usuario:
-  > "El installer técnico aún no ha corrido. Necesito que abras terminal y ejecutes:
-  >
-  > ```bash
-  > bash scripts/install.sh
-  > ```
-  >
-  > Cuando termine, vuelve aquí y di `/install` otra vez."
+- El installer técnico aún no ha corrido. **Lánzalo tú** (con el OK del usuario, no hace falta que abra terminal):
+  > "El installer técnico aún no ha corrido. Te lo lanzo yo ahora (~30s). ¿Le doy?"
+  - Con su OK, ejecuta con la tool `Bash`: `bash scripts/install.sh` (permitido en `.claude/settings.json`).
+  - En Windows corre igual vía Git Bash. Si `bash` no está disponible para Claude Code, pídele instalar Git Bash y, como alternativa, que lo ejecute él desde una terminal Git Bash.
+  - Parsea la salida (`[OK]`/`[WARN]`/`[ERROR]`). Si hay `[ERROR]`, para y explícalo en castellano.
 - **NO crees el state file tú**. Solo lo crea `scripts/install.sh`.
-- Para aquí.
+- Cuando `install.sh` termine bien, vuelve a leer el state y sigue en el Paso 2.
 
 ### Paso 2 · Evaluar progreso
 
@@ -39,21 +36,17 @@ Mensaje:
 Sugiere ejecutar `/start-here` para arrancar el flujo normal de trabajo.
 
 #### Caso B: fase `prereqs` o `sinapsis-engine` pendiente/failed
-Estas fases las debe ejecutar `bash scripts/install.sh` desde terminal — TÚ NO puedes ejecutarlas desde Claude Code.
+Estas fases las ejecuta `bash scripts/install.sh`. **Puedes lanzarlo tú** desde Claude Code (con el OK del usuario) — no hace falta que abra una terminal.
 
 Mensaje:
-> "Faltan fases técnicas que requieren ejecutar el installer desde terminal. Abre tu terminal en este repo y ejecuta:
->
-> ```bash
-> bash scripts/install.sh --resume
-> ```
->
-> Esto retoma desde la fase pendiente: `<nombre-fase>`."
+> "Faltan fases técnicas (`<nombre-fase>`). Te las lanzo yo ahora (`bash scripts/install.sh --resume`, ~30s). ¿Le doy?"
 
-Si la fase está `failed`, lee `errors[]` del state file y muestra al usuario el último error para que pueda resolverlo:
-> "El último intento falló con: `<mensaje>`. Una vez lo arregles, ejecuta el comando de arriba."
+Con su OK, ejecuta con la tool `Bash`: `bash scripts/install.sh --resume`. Parsea la salida; si hay `[ERROR]`, explícalo en castellano y no sigas al resto de fases.
 
-**Para aquí. NO intentes ejecutar bash desde dentro de Claude Code para esto.**
+Si la fase está `failed`, lee `errors[]` del state file y muestra el último error **de esa fase** para dar contexto antes de reintentar:
+> "El intento anterior falló con: `<mensaje>`. Lo reintento ahora."
+
+En Windows corre igual vía Git Bash. Solo si `bash` no está disponible para Claude Code, pídele que lo ejecute él desde una terminal Git Bash.
 
 #### Caso C: fase `context-files` o `operator-state` pendiente/in-progress
 Esto es onboarding conversacional. Tú lo ejecutas directamente.

--- a/.claude/skills/_meta/health-check/SKILL.md
+++ b/.claude/skills/_meta/health-check/SKILL.md
@@ -53,16 +53,21 @@ Esta sección es la que evita "instalaciones fantasma". No te fíes de que el ar
 | `_operator-state.json` parseable | `node -e "JSON.parse(require('fs').readFileSync('~/.claude/skills/_operator-state.json'))"` no falla | 🔴 |
 | `_operator-state.json` tiene campos mínimos | `.operator.name` y `.operator.language` no son null/empty | 🟡 (sin esto el wizard no ha terminado) |
 | `_catalog.json` parseable | mismo | 🟡 |
-| Hooks ejecutables (5 hooks) | `_passive-activator.sh`, `_instinct-activator.sh`, `_session-learner.sh`, `_project-context.sh`, `_eod-gather.sh` existen Y tienen permiso `+x` | 🔴 si falla ≥2, 🟡 si falla 1 |
+| Hooks ejecutables (7 hooks) | `_passive-activator.sh`, `_instinct-activator.sh`, `_session-learner.sh`, `_project-context.sh`, `_eod-gather.sh`, `_dream.sh`, `_precompact-guard.sh` existen Y tienen permiso `+x` | 🔴 si falla ≥2, 🟡 si falla 1 |
 | ≥1 SKILL.md instalada | `find ~/.claude/skills -maxdepth 3 -name SKILL.md` devuelve ≥1 resultado | 🔴 |
-| Hooks registrados en settings.json | `~/.claude/settings.json` parseable Y contiene la sección `hooks.PreToolUse` con referencias a `_passive-activator.sh` | 🟡 |
+| Hooks REALMENTE cableados en settings.json | `~/.claude/settings.json` parseable Y `hooks` referencia `_passive-activator.sh`, `_instinct-activator.sh` (PreToolUse) y `_session-learner.sh` (Stop). **Este es el check funcional real**: si faltan, Sinapsis está instalado pero el motor de aprendizaje NO se dispara (muerte silenciosa). Ojo: que exista la palabra `"hooks"` NO basta. | 🔴 |
 | Install-gate registrado | `~/.claude/settings.json` contiene `hooks.SessionStart` con referencia a `_install-gate.sh` | 🟡 |
 | **DRIFT check** | Si `_install-state.json.phases.sinapsis-engine.status == "done"` Y alguno de los anteriores falla → **DRIFT** | 🔴 con flag "STATE DRIFT" |
 
 Para los checks de hooks ejecutables, usa Bash:
 ```bash
-for h in _passive-activator.sh _instinct-activator.sh _session-learner.sh _project-context.sh _eod-gather.sh; do
+for h in _passive-activator.sh _instinct-activator.sh _session-learner.sh _project-context.sh _eod-gather.sh _dream.sh _precompact-guard.sh; do
   [ -x "$HOME/.claude/skills/$h" ] && echo "OK $h" || echo "FAIL $h"
+done
+
+# Check funcional real: ¿están los hooks de Sinapsis cableados en settings.json?
+for h in _passive-activator.sh _instinct-activator.sh _session-learner.sh; do
+  grep -q "$h" "$HOME/.claude/settings.json" 2>/dev/null && echo "WIRED $h" || echo "NOT-WIRED $h"
 done
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,11 @@ Variantes que también debes reconocer:
 - "Instala el OS de iAmasters"
 - "Configura mi sistema con iAmasters OS"
 - "Quiero usar iAmasters OS"
+- **"instala esto" · "instálamelo" · "monta el sistema" · "install this" · "set this up"** (dentro de la carpeta del repo)
+- El comando `/instala`
 - Cualquier URL del repo `iamasters-academy/iamasters-os`
+
+> Ante cualquiera de estas frases, el camino canónico es el comando **`/instala`** (`.claude/commands/instala.md`): lo ejecutas TÚ con la tool `Bash`, sin mandar al usuario a la terminal. El workflow de abajo es su versión detallada.
 
 ### Tu workflow exacto (no improvises)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ Formato basado en [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.10.2] — 2026-07-17
+
+### Fixed
+- **Los hooks de Sinapsis no se cableaban si `~/.claude/settings.json` ya existía** (`scripts/install.sh`). El instalador vendored de Sinapsis, ante un `settings.json` preexistente (el caso de casi todos los usuarios de Claude Code), solo imprimía *"merge manually"* y NO registraba sus hooks. Consecuencias: (a) en máquinas cuyo `settings.json` no tenía sección `hooks`, la validación profunda abortaba la instalación con *"Sinapsis se ejecutó pero la validación profunda falla"*; (b) en las que sí tenían hooks de otra cosa, la validación pasaba en falso y **el motor de aprendizaje de Sinapsis quedaba inerte sin avisar**. Nuevo `ensure_sinapsis_hooks()`: deep-merge **idempotente** de los 7 hooks de la plantilla de Sinapsis dentro del `settings.json` del operador, preservando permisos/config/hooks previos. El upstream de Luis (v4.8.0) tampoco resuelve esto, por eso se arregla en la capa OS.
+- **Validación profunda endurecida** (`scripts/install.sh`, skill `health-check`): antes comprobaba solo 3 de los 7 hooks y un `grep '"hooks"'` que daba falso OK. Ahora valida los 7 hooks y el **cableado real** de los activadores en `settings.json`.
+- **Error fantasma en `/install-status`** (`scripts/install.sh`): `mark_phase_done` no limpiaba el array global `errors[]`, así que un fallo de un intento previo seguía apareciendo tras un reintento exitoso. Nuevo `clear_phase_errors()`; se purga al completar o revalidar una fase.
+
+### Changed
+- **Instalación sin terminal (primary path).** Claude Code ahora **ejecuta el installer por ti** con tu OK, en vez de mandarte a una terminal. Nuevo comando **`/instala`** (y disparadores en lenguaje natural: "instala esto", "install this", "set this up") que detecta el SO, corre `bash scripts/install.sh` (Mac/Linux y Windows vía Git Bash), verifica y sigue con el onboarding. Alineados `CLAUDE.md` (install gate), `/install`, `AGENTS.md` y `README.md`, que antes se contradecían (AGENTS decía "ejecútalo" y el gate lo prohibía).
+
+---
+
 ## [0.10.1] — 2026-06-12
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,7 +36,7 @@ keywords:
   - iamasters-academy
 license: MIT
 license-url: "https://github.com/iamasters-academy/iamasters-os/blob/main/LICENSE"
-version: "0.10.1"
+version: "0.10.2"
 date-released: "2026-06-11"
 preferred-citation:
   type: software

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,12 @@ Antes de responder al primer mensaje del usuario en este repo, **debes** comprob
 **Comprobación obligatoria** (en este orden):
 
 1. **¿Existe el state file?**
-   - Si NO existe → la instalación técnica nunca corrió. Indica al usuario:
-     > "iAmasters OS no está instalado. Necesito que ejecutes desde terminal: `bash scripts/install.sh`. Cuando termine, vuelve aquí."
-   - NO crees archivos manualmente para simular instalación. NO marques nada como instalado.
+   - Si NO existe → la instalación técnica nunca corrió. **Ofrécete a instalarlo tú** (es lo más cómodo: el usuario no suele usar terminal):
+     > "iAmasters OS aún no está instalado. Te lo instalo yo ahora mismo (Sinapsis + capa OS, ~30s). ¿Le doy?"
+     - Con su OK, ejecuta `bash scripts/install.sh` con la tool `Bash` (ya está permitido en `.claude/settings.json`, no pide permiso). En Windows corre igual vía Git Bash, que Claude Code ya requiere; si `bash` no está disponible, pídele instalar Git Bash.
+     - Parsea la salida estructurada (`[OK]`/`[SKIP]`/`[WARN]`/`[ERROR]`). Si hay `[ERROR]`, diagnostica y explícalo en castellano.
+     - Cuando termine bien, continúa con `/install` para las fases conversacionales.
+   - NO crees archivos manualmente para simular instalación. NO marques nada como instalado a mano — de eso se encarga `install.sh`.
 
 2. **Si existe, ¿todas las fases `required: true` están en `status: "done"`?**
    - Si NO → la instalación está incompleta. Invoca el comando `/install` (o el wizard directamente, según la fase pendiente).
@@ -237,9 +240,9 @@ Viven en `skills-library/` (cero coste de contexto hasta instalarlas). Instalar:
 
 ### Slash commands
 
-`/install` · `/install-status` · `/start-here` · `/wrap-up` · `/doctor` · `/actualiza` · `/restaura` · `/backup` · `/skills` · `/add-client` · `/install-skill` · `/install-mcp` · `/aprende` · `/deep-dive` · `/recuerda` · `/loops` · `/evalua-loop`
+`/instala` · `/install` · `/install-status` · `/start-here` · `/wrap-up` · `/doctor` · `/actualiza` · `/restaura` · `/backup` · `/skills` · `/add-client` · `/install-skill` · `/install-mcp` · `/aprende` · `/deep-dive` · `/recuerda` · `/loops` · `/evalua-loop`
 
-Los dos primeros (`/install`, `/install-status`) son nuevos en v0.6 y son la **única vía oficial** para gestionar la instalación desde dentro de Claude Code.
+`/instala` es el punto de entrada **sin terminal**: se dispara con "instala esto" / "install this" y ejecuta el installer por ti (Mac y Windows con Git Bash). `/install` e `/install-status` gestionan/consultan la instalación por fases una vez arrancada.
 
 ### Capa 2 — skills externas
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/iamasters-academy/iamasters-os/releases"><img src="https://img.shields.io/badge/version-v0.10.1-orange.svg" alt="Version"></a>
+  <a href="https://github.com/iamasters-academy/iamasters-os/releases"><img src="https://img.shields.io/badge/version-v0.10.2-orange.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="vendor/sinapsis/"><img src="https://img.shields.io/badge/engine-Sinapsis%20v4.6.1-purple.svg" alt="Powered by Sinapsis"></a>
   <a href="https://angelaparicio.com"><img src="https://img.shields.io/badge/maintained%20by-Angel%20Aparicio-ff8c42.svg" alt="Maintained by Angel Aparicio"></a>
@@ -21,7 +21,14 @@
 
 ## 🚀 Instalación (v0.6+ — con install gate)
 
-**Camino corto (recomendado)** — desde terminal:
+**Camino recomendado — sin terminal.** Clona el repo, abre Claude Code (Claude Desktop) en la carpeta y escribe:
+
+> **instala esto**
+
+Claude ejecuta el installer por ti (dispara el comando `/instala`), verifica la instalación y sigue con tu onboarding. Funciona en **Mac y Windows** (en Windows, Claude Code ya usa Git Bash, que es lo único que necesita el installer).
+
+<details>
+<summary>Camino manual (terminal) — si lo prefieres</summary>
 
 ```bash
 git clone https://github.com/iamasters-academy/iamasters-os.git ~/iamasters-os
@@ -29,7 +36,10 @@ cd ~/iamasters-os
 bash scripts/install.sh
 ```
 
-Esto instala las fases técnicas (prereqs + Sinapsis engine) con validación profunda. Cuando termine, abre Claude Code en esta carpeta y el resto se completa por dentro:
+En **Windows** ejecútalo desde una terminal **Git Bash** (incluida en [Git para Windows](https://git-scm.com/download/win)), no desde cmd/PowerShell.
+</details>
+
+Esto instala las fases técnicas (prereqs + Sinapsis engine) con validación profunda. Cuando termine, el resto se completa dentro de Claude Code:
 
 1. El hook **SessionStart** detecta que faltan fases (onboarding + welcome) y guía al agente.
 2. El agente invoca el comando `/install` que orquesta las 4 fases conversacionales restantes.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -222,10 +222,41 @@ json.dump(s, open(f, 'w'), indent=2)
     esac
 }
 
+clear_phase_errors() {
+    # $1 = phase — elimina del array global s.errors las entradas de esa fase.
+    # Sin esto, un error de un intento previo persiste para siempre y sigue
+    # apareciendo en /install-status aunque el reintento acabe en 'done'.
+    case "$JSON_RUNTIME" in
+        node)
+            node -e "
+                const fs = require('fs');
+                const f = '$WIN_STATE_FILE';
+                const s = JSON.parse(fs.readFileSync(f, 'utf8'));
+                s.errors = (s.errors || []).filter(e => e.phase !== '$1');
+                s.lastUpdatedAt = new Date().toISOString();
+                fs.writeFileSync(f, JSON.stringify(s, null, 2));
+            "
+            ;;
+        python3|python)
+            "$JSON_RUNTIME" -c "
+import json, datetime
+f = '$WIN_STATE_FILE'
+s = json.load(open(f))
+s['errors'] = [e for e in s.get('errors', []) if e.get('phase') != '$1']
+s['lastUpdatedAt'] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+json.dump(s, open(f, 'w'), indent=2)
+"
+            ;;
+    esac
+}
+
 mark_phase_done() {
     # $1 = phase name
     json_set_phase "$1" "status" '"done"'
     json_set_phase "$1" "validatedAt" "\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\""
+    # Purga los errores de esta fase: si un intento previo falló y ahora pasa,
+    # el error viejo NO debe seguir mostrándose (era un fantasma que asustaba).
+    clear_phase_errors "$1"
 
     # Append to completedPhases array
     case "$JSON_RUNTIME" in
@@ -423,8 +454,10 @@ validate_sinapsis_deep() {
         fi
     fi
 
-    # Hooks ejecutables (los que Sinapsis instala)
-    for hook in _passive-activator.sh _instinct-activator.sh _session-learner.sh; do
+    # Hooks ejecutables — los 7 que Sinapsis instala (antes solo se validaban 3,
+    # así que una instalación con hooks a medias pasaba como buena).
+    for hook in _passive-activator.sh _instinct-activator.sh _session-learner.sh \
+                _project-context.sh _eod-gather.sh _dream.sh _precompact-guard.sh; do
         if [ ! -f "$SKILLS_DIR/$hook" ]; then
             warn "  validación: falta hook $hook"
             issues=$((issues+1))
@@ -442,15 +475,25 @@ validate_sinapsis_deep() {
         issues=$((issues+1))
     fi
 
-    # settings.json con sección hooks (señal de que Sinapsis registró sus hooks)
-    if [ -f "$CLAUDE_HOME/settings.json" ]; then
-        if ! grep -q '"hooks"' "$CLAUDE_HOME/settings.json"; then
-            warn "  validación: ~/.claude/settings.json existe pero no tiene sección 'hooks'"
-            issues=$((issues+1))
-        fi
-    else
+    # settings.json debe existir Y tener los hooks de Sinapsis REALMENTE cableados.
+    # No basta con que aparezca la palabra "hooks": eso daba falso OK cuando el
+    # usuario ya tenía settings.json con hooks de otra cosa y los de Sinapsis
+    # nunca se registraron → motor de aprendizaje muerto en silencio.
+    if [ ! -f "$CLAUDE_HOME/settings.json" ]; then
         warn "  validación: ~/.claude/settings.json no existe"
         issues=$((issues+1))
+    elif ! json_validate "$CLAUDE_HOME/settings.json"; then
+        warn "  validación: ~/.claude/settings.json no es JSON parseable"
+        issues=$((issues+1))
+    else
+        local missing_wired=0 h
+        for h in _passive-activator.sh _instinct-activator.sh _session-learner.sh; do
+            grep -q "$h" "$CLAUDE_HOME/settings.json" || missing_wired=$((missing_wired+1))
+        done
+        if [ "$missing_wired" -gt 0 ]; then
+            warn "  validación: settings.json no cablea los hooks de Sinapsis ($missing_wired/3 activadores ausentes) · ejecuta el instalador para arreglarlo"
+            issues=$((issues+1))
+        fi
     fi
 
     return $issues
@@ -477,6 +520,93 @@ record_sinapsis_validation() {
         "{\"operator_state_json_valid\": $op_valid, \"catalog_json_valid\": $cat_valid, \"hooks_executable\": $hooks_ok, \"skills_count\": ${skill_count:-0}}"
 }
 
+ensure_sinapsis_hooks() {
+    # FIX capa OS: el instalador vendored de Sinapsis NO registra sus hooks si
+    # ~/.claude/settings.json YA existe (solo imprime "merge manually"). Como casi
+    # todos los usuarios ya tienen settings.json, sus hooks nunca se cableaban y el
+    # motor de aprendizaje quedaba inerte (y en el peor caso la validación abortaba
+    # toda la instalación). Aquí hacemos un DEEP-MERGE IDEMPOTENTE de los hooks de
+    # la plantilla de Sinapsis dentro del settings.json del usuario, preservando
+    # cualquier hook/permiso/config previo. Re-ejecutar = no-op.
+    local template="$SINAPSIS_VENDOR/core/settings.template.json"
+    local settings="$CLAUDE_HOME/settings.json"
+    if [ ! -f "$template" ]; then
+        warn "  no encontrado $template · no se pueden cablear los hooks de Sinapsis"
+        return 1
+    fi
+    mkdir -p "$CLAUDE_HOME"
+
+    local _tpl _set
+    _tpl="$(_win_path "$template")"
+    _set="$(_win_path "$settings")"
+
+    case "$JSON_RUNTIME" in
+        node)
+            node -e '
+const fs = require("fs"), path = require("path");
+const tplPath = process.argv[1], setPath = process.argv[2];
+function strip(o){ if(Array.isArray(o)) return o.map(strip); if(o && typeof o==="object"){ const r={}; for(const [k,v] of Object.entries(o)){ if(k.startsWith("_")) continue; r[k]=strip(v);} return r;} return o; }
+const tpl = strip(JSON.parse(fs.readFileSync(tplPath, "utf8")));
+let cur = {};
+if (fs.existsSync(setPath)) { try { cur = JSON.parse(fs.readFileSync(setPath, "utf8")); } catch(e){ console.error("settings.json existe pero no es JSON parseable"); process.exit(3); } }
+cur.hooks = (cur.hooks && typeof cur.hooks === "object") ? cur.hooks : {};
+const cmdOf = h => (h && typeof h === "object" && h.command) ? h.command : JSON.stringify(h);
+for (const [event, groups] of Object.entries(tpl.hooks || {})) {
+  if (!Array.isArray(cur.hooks[event])) cur.hooks[event] = [];
+  for (const g of groups) {
+    let dst = cur.hooks[event].find(x => (x.matcher || "") === (g.matcher || ""));
+    if (!dst) { cur.hooks[event].push(JSON.parse(JSON.stringify(g))); continue; }
+    if (!Array.isArray(dst.hooks)) dst.hooks = [];
+    const seen = new Set(dst.hooks.map(cmdOf));
+    for (const hk of (g.hooks || [])) { if (!seen.has(cmdOf(hk))) { dst.hooks.push(hk); seen.add(cmdOf(hk)); } }
+  }
+}
+fs.mkdirSync(path.dirname(setPath), { recursive: true });
+fs.writeFileSync(setPath, JSON.stringify(cur, null, 2) + "\n");
+' "$_tpl" "$_set"
+            ;;
+        python3|python)
+            "$JSON_RUNTIME" - "$_tpl" "$_set" <<'PYEOF'
+import json, os, sys
+tplPath, setPath = sys.argv[1], sys.argv[2]
+def strip(o):
+    if isinstance(o, list): return [strip(x) for x in o]
+    if isinstance(o, dict): return {k: strip(v) for k, v in o.items() if not k.startswith('_')}
+    return o
+with open(tplPath) as fh:
+    tpl = strip(json.load(fh))
+cur = {}
+if os.path.exists(setPath):
+    try:
+        with open(setPath) as fh:
+            cur = json.load(fh)
+    except Exception:
+        sys.stderr.write('settings.json existe pero no es JSON parseable\n'); sys.exit(3)
+if not isinstance(cur.get('hooks'), dict):
+    cur['hooks'] = {}
+def cmd_of(h):
+    return h['command'] if isinstance(h, dict) and 'command' in h else json.dumps(h, sort_keys=True)
+for event, groups in (tpl.get('hooks') or {}).items():
+    if not isinstance(cur['hooks'].get(event), list):
+        cur['hooks'][event] = []
+    for g in groups:
+        dst = next((x for x in cur['hooks'][event] if x.get('matcher', '') == g.get('matcher', '')), None)
+        if dst is None:
+            cur['hooks'][event].append(json.loads(json.dumps(g))); continue
+        if not isinstance(dst.get('hooks'), list):
+            dst['hooks'] = []
+        seen = set(cmd_of(h) for h in dst['hooks'])
+        for hk in g.get('hooks', []):
+            if cmd_of(hk) not in seen:
+                dst['hooks'].append(hk); seen.add(cmd_of(hk))
+os.makedirs(os.path.dirname(setPath), exist_ok=True)
+with open(setPath, 'w') as fh:
+    json.dump(cur, fh, indent=2); fh.write('\n')
+PYEOF
+            ;;
+    esac
+}
+
 phase_sinapsis_engine() {
     local current_status
     current_status=$(json_get_phase_status "sinapsis-engine")
@@ -484,6 +614,7 @@ phase_sinapsis_engine() {
         # Aún así re-validamos para detectar drift (alguien borró archivos manualmente)
         if validate_sinapsis_deep >/dev/null 2>&1; then
             record_sinapsis_validation
+            clear_phase_errors "sinapsis-engine"  # purga fantasmas de intentos viejos ya resueltos
             skip "sinapsis-engine · ya instalado y validado (status=done)"
             return 0
         else
@@ -526,6 +657,15 @@ phase_sinapsis_engine() {
         mark_phase_failed "sinapsis-engine" "vendor/sinapsis/install.sh devolvió error · revisa el output anterior"
     fi
     cd "$prev_dir"
+
+    # FIX capa OS: cablear los hooks de Sinapsis en settings.json (idempotente).
+    # El instalador vendored NO lo hace si settings.json ya existía.
+    info "Cableando hooks de Sinapsis en ~/.claude/settings.json..."
+    if ensure_sinapsis_hooks; then
+        ok "Hooks de Sinapsis cableados en settings.json"
+    else
+        warn "No se pudieron cablear los hooks automáticamente · revisa ~/.claude/settings.json"
+    fi
 
     # Validación POST-instalación (esto es lo que evita "instalaciones fantasma")
     info "Validando instalación de Sinapsis (validación profunda)..."


### PR DESCRIPTION
## Qué arregla

Una miembro reportó `[sinapsis-engine] "Sinapsis se ejecutó pero la validación profunda falla"`. La causa raíz y su daño silencioso:

### 🔴 Los hooks de Sinapsis no se cableaban si `settings.json` ya existía
El instalador vendored de Sinapsis, ante un `~/.claude/settings.json` preexistente (el caso de casi todos), solo imprime *"merge manually"* y **no registra sus hooks**. Consecuencia doble:
- settings sin sección `hooks` → la validación profunda abortaba la instalación (el error de la miembro).
- settings con hooks de otra cosa → validación pasaba en falso y **el motor de aprendizaje quedaba inerte sin avisar**.

El upstream de Luis (v4.8.0) tampoco lo resuelve → se arregla en la **capa OS**.

## Cambios

**P0 — fix del error**
- `ensure_sinapsis_hooks()`: deep-merge **idempotente** de los 7 hooks de la plantilla de Sinapsis en `settings.json`, preservando permisos/config/hooks del usuario.
- `validate_sinapsis_deep` endurecida: valida los **7** hooks (antes 3) y el **cableado real** en `settings.json` (antes `grep '"hooks"'` laxo → falso OK). Espejado en la skill `health-check`.
- `clear_phase_errors()`: `mark_phase_done` y el camino *skip* purgan el error fantasma → deja de aparecer en `/install-status` tras un reintento OK.

**P1 — instalación sin terminal**
- Nuevo comando **`/instala`** + disparadores en lenguaje natural ("instala esto", "install this"). Claude ejecuta el installer por el usuario (Mac + Windows vía Git Bash).
- Alineados `CLAUDE.md` (install gate), `/install`, `AGENTS.md` y `README.md`, que se contradecían.

**Registros**: v0.10.2 (CHANGELOG, CITATION, badge README).

## Verificación
- Reproducido el escenario exacto de la miembro (settings.json preexistente sin hooks) corriendo el `install.sh` real en HOME sandbox: `sinapsis-engine: done`, validación `true`, hooks cableados, `errors[]` vacío, permisos/`model` preservados, re-run idempotente.
- Probada la purga del fantasma con el mensaje literal reportado.
- Rama node y python del merge validadas por separado.
- Los 5 checks del CI del repo pasan en local (sintaxis, links, secrets, frontmatter, registry 37 skills).

## Notas
- **No se toca `vendor/sinapsis/`** (dominio de Luis). Los bugs del motor (merge de hooks en el propio Sinapsis, `rm -rf` que borra en vez de archivar, `xcopy` Windows, fixes de v4.6.2) van en un informe aparte para Luis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)