### PR TITLE
fix(update): /actualiza repara los hooks de Sinapsis en instalaciones existentes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Formato basado en [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - **Instalación sin terminal (primary path).** Claude Code ahora **ejecuta el installer por ti** con tu OK, en vez de mandarte a una terminal. Nuevo comando **`/instala`** (y disparadores en lenguaje natural: "instala esto", "install this", "set this up") que detecta el SO, corre `bash scripts/install.sh` (Mac/Linux y Windows vía Git Bash), verifica y sigue con el onboarding. Alineados `CLAUDE.md` (install gate), `/install`, `AGENTS.md` y `README.md`, que antes se contradecían (AGENTS decía "ejecútalo" y el gate lo prohibía).
+- **`/actualiza` ahora también REPARA los hooks.** `update.sh` re-cablea los hooks de Sinapsis al final (vía el nuevo `scripts/_ensure-sinapsis-hooks.sh`, compartido con `install.sh`). Así, los miembros que ya tenían el motor de aprendizaje inerte (por haber instalado con la versión previa) quedan arreglados con solo decir **"actualiza"** — sin reinstalar. Idempotente y preserva permisos/config/hooks del operador.
 
 ---
 

--- a/scripts/_ensure-sinapsis-hooks.sh
+++ b/scripts/_ensure-sinapsis-hooks.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# ============================================================
+#  _ensure-sinapsis-hooks.sh
+#  Deep-merge IDEMPOTENTE de los hooks de Sinapsis en el
+#  settings.json del operador, preservando permisos/config/hooks
+#  previos. Re-ejecutar = no-op.
+#
+#  Lo usan:
+#   - install.sh  → tras instalar Sinapsis (el instalador vendored
+#     NO registra hooks si settings.json ya existía).
+#   - update.sh   → para que /actualiza REPARE instalaciones viejas
+#     cuyos hooks nunca se cablearon (motor de aprendizaje inerte).
+#
+#  Uso: _ensure-sinapsis-hooks.sh [TEMPLATE_JSON] [SETTINGS_JSON]
+#   TEMPLATE_JSON  por defecto: ../vendor/sinapsis/core/settings.template.json
+#   SETTINGS_JSON  por defecto: ~/.claude/settings.json
+# ============================================================
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE="${1:-$REPO_ROOT/vendor/sinapsis/core/settings.template.json}"
+SETTINGS="${2:-$HOME/.claude/settings.json}"
+
+if [ ! -f "$TEMPLATE" ]; then
+    echo "[ensure-hooks] no encontrado $TEMPLATE" >&2
+    exit 2
+fi
+mkdir -p "$(dirname "$SETTINGS")"
+
+# Windows / Git Bash (MSYS): cygpath -m para que node/python entiendan la ruta.
+if [[ -n "$MSYSTEM" ]] && command -v cygpath >/dev/null 2>&1; then
+    TEMPLATE="$(cygpath -m "$TEMPLATE")"
+    SETTINGS="$(cygpath -m "$SETTINGS")"
+fi
+
+# Runtime JSON: en MSYS preferimos python (node malinterpreta rutas POSIX).
+RT=""
+if [[ -n "$MSYSTEM" ]]; then
+    if command -v python3 >/dev/null 2>&1; then RT=python3
+    elif command -v python >/dev/null 2>&1 && python --version 2>&1 | grep -q "Python 3"; then RT=python
+    elif command -v node >/dev/null 2>&1; then RT=node
+    fi
+elif command -v node >/dev/null 2>&1; then RT=node
+elif command -v python3 >/dev/null 2>&1; then RT=python3
+elif command -v python >/dev/null 2>&1 && python --version 2>&1 | grep -q "Python 3"; then RT=python
+fi
+if [ -z "$RT" ]; then
+    echo "[ensure-hooks] ni node ni Python 3 disponibles" >&2
+    exit 3
+fi
+
+case "$RT" in
+    node)
+        node -e '
+const fs = require("fs"), path = require("path");
+const tplPath = process.argv[1], setPath = process.argv[2];
+function strip(o){ if(Array.isArray(o)) return o.map(strip); if(o && typeof o==="object"){ const r={}; for(const [k,v] of Object.entries(o)){ if(k.startsWith("_")) continue; r[k]=strip(v);} return r;} return o; }
+const tpl = strip(JSON.parse(fs.readFileSync(tplPath, "utf8")));
+let cur = {};
+if (fs.existsSync(setPath)) { try { cur = JSON.parse(fs.readFileSync(setPath, "utf8")); } catch(e){ console.error("settings.json existe pero no es JSON parseable"); process.exit(4); } }
+cur.hooks = (cur.hooks && typeof cur.hooks === "object") ? cur.hooks : {};
+const cmdOf = h => (h && typeof h === "object" && h.command) ? h.command : JSON.stringify(h);
+for (const [event, groups] of Object.entries(tpl.hooks || {})) {
+  if (!Array.isArray(cur.hooks[event])) cur.hooks[event] = [];
+  for (const g of groups) {
+    let dst = cur.hooks[event].find(x => (x.matcher || "") === (g.matcher || ""));
+    if (!dst) { cur.hooks[event].push(JSON.parse(JSON.stringify(g))); continue; }
+    if (!Array.isArray(dst.hooks)) dst.hooks = [];
+    const seen = new Set(dst.hooks.map(cmdOf));
+    for (const hk of (g.hooks || [])) { if (!seen.has(cmdOf(hk))) { dst.hooks.push(hk); seen.add(cmdOf(hk)); } }
+  }
+}
+fs.mkdirSync(path.dirname(setPath), { recursive: true });
+fs.writeFileSync(setPath, JSON.stringify(cur, null, 2) + "\n");
+' "$TEMPLATE" "$SETTINGS"
+        ;;
+    python3|python)
+        "$RT" - "$TEMPLATE" "$SETTINGS" <<'PYEOF'
+import json, os, sys
+tplPath, setPath = sys.argv[1], sys.argv[2]
+def strip(o):
+    if isinstance(o, list): return [strip(x) for x in o]
+    if isinstance(o, dict): return {k: strip(v) for k, v in o.items() if not k.startswith('_')}
+    return o
+with open(tplPath) as fh:
+    tpl = strip(json.load(fh))
+cur = {}
+if os.path.exists(setPath):
+    try:
+        with open(setPath) as fh:
+            cur = json.load(fh)
+    except Exception:
+        sys.stderr.write('settings.json existe pero no es JSON parseable\n'); sys.exit(4)
+if not isinstance(cur.get('hooks'), dict):
+    cur['hooks'] = {}
+def cmd_of(h):
+    return h['command'] if isinstance(h, dict) and 'command' in h else json.dumps(h, sort_keys=True)
+for event, groups in (tpl.get('hooks') or {}).items():
+    if not isinstance(cur['hooks'].get(event), list):
+        cur['hooks'][event] = []
+    for g in groups:
+        dst = next((x for x in cur['hooks'][event] if x.get('matcher', '') == g.get('matcher', '')), None)
+        if dst is None:
+            cur['hooks'][event].append(json.loads(json.dumps(g))); continue
+        if not isinstance(dst.get('hooks'), list):
+            dst['hooks'] = []
+        seen = set(cmd_of(h) for h in dst['hooks'])
+        for hk in g.get('hooks', []):
+            if cmd_of(hk) not in seen:
+                dst['hooks'].append(hk); seen.add(cmd_of(hk))
+os.makedirs(os.path.dirname(setPath), exist_ok=True)
+with open(setPath, 'w') as fh:
+    json.dump(cur, fh, indent=2); fh.write('\n')
+PYEOF
+        ;;
+esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -528,83 +528,13 @@ ensure_sinapsis_hooks() {
     # toda la instalación). Aquí hacemos un DEEP-MERGE IDEMPOTENTE de los hooks de
     # la plantilla de Sinapsis dentro del settings.json del usuario, preservando
     # cualquier hook/permiso/config previo. Re-ejecutar = no-op.
+    # Delega en el script compartido (mismo merge que usa update.sh, DRY).
     local template="$SINAPSIS_VENDOR/core/settings.template.json"
-    local settings="$CLAUDE_HOME/settings.json"
     if [ ! -f "$template" ]; then
         warn "  no encontrado $template · no se pueden cablear los hooks de Sinapsis"
         return 1
     fi
-    mkdir -p "$CLAUDE_HOME"
-
-    local _tpl _set
-    _tpl="$(_win_path "$template")"
-    _set="$(_win_path "$settings")"
-
-    case "$JSON_RUNTIME" in
-        node)
-            node -e '
-const fs = require("fs"), path = require("path");
-const tplPath = process.argv[1], setPath = process.argv[2];
-function strip(o){ if(Array.isArray(o)) return o.map(strip); if(o && typeof o==="object"){ const r={}; for(const [k,v] of Object.entries(o)){ if(k.startsWith("_")) continue; r[k]=strip(v);} return r;} return o; }
-const tpl = strip(JSON.parse(fs.readFileSync(tplPath, "utf8")));
-let cur = {};
-if (fs.existsSync(setPath)) { try { cur = JSON.parse(fs.readFileSync(setPath, "utf8")); } catch(e){ console.error("settings.json existe pero no es JSON parseable"); process.exit(3); } }
-cur.hooks = (cur.hooks && typeof cur.hooks === "object") ? cur.hooks : {};
-const cmdOf = h => (h && typeof h === "object" && h.command) ? h.command : JSON.stringify(h);
-for (const [event, groups] of Object.entries(tpl.hooks || {})) {
-  if (!Array.isArray(cur.hooks[event])) cur.hooks[event] = [];
-  for (const g of groups) {
-    let dst = cur.hooks[event].find(x => (x.matcher || "") === (g.matcher || ""));
-    if (!dst) { cur.hooks[event].push(JSON.parse(JSON.stringify(g))); continue; }
-    if (!Array.isArray(dst.hooks)) dst.hooks = [];
-    const seen = new Set(dst.hooks.map(cmdOf));
-    for (const hk of (g.hooks || [])) { if (!seen.has(cmdOf(hk))) { dst.hooks.push(hk); seen.add(cmdOf(hk)); } }
-  }
-}
-fs.mkdirSync(path.dirname(setPath), { recursive: true });
-fs.writeFileSync(setPath, JSON.stringify(cur, null, 2) + "\n");
-' "$_tpl" "$_set"
-            ;;
-        python3|python)
-            "$JSON_RUNTIME" - "$_tpl" "$_set" <<'PYEOF'
-import json, os, sys
-tplPath, setPath = sys.argv[1], sys.argv[2]
-def strip(o):
-    if isinstance(o, list): return [strip(x) for x in o]
-    if isinstance(o, dict): return {k: strip(v) for k, v in o.items() if not k.startswith('_')}
-    return o
-with open(tplPath) as fh:
-    tpl = strip(json.load(fh))
-cur = {}
-if os.path.exists(setPath):
-    try:
-        with open(setPath) as fh:
-            cur = json.load(fh)
-    except Exception:
-        sys.stderr.write('settings.json existe pero no es JSON parseable\n'); sys.exit(3)
-if not isinstance(cur.get('hooks'), dict):
-    cur['hooks'] = {}
-def cmd_of(h):
-    return h['command'] if isinstance(h, dict) and 'command' in h else json.dumps(h, sort_keys=True)
-for event, groups in (tpl.get('hooks') or {}).items():
-    if not isinstance(cur['hooks'].get(event), list):
-        cur['hooks'][event] = []
-    for g in groups:
-        dst = next((x for x in cur['hooks'][event] if x.get('matcher', '') == g.get('matcher', '')), None)
-        if dst is None:
-            cur['hooks'][event].append(json.loads(json.dumps(g))); continue
-        if not isinstance(dst.get('hooks'), list):
-            dst['hooks'] = []
-        seen = set(cmd_of(h) for h in dst['hooks'])
-        for hk in g.get('hooks', []):
-            if cmd_of(hk) not in seen:
-                dst['hooks'].append(hk); seen.add(cmd_of(hk))
-os.makedirs(os.path.dirname(setPath), exist_ok=True)
-with open(setPath, 'w') as fh:
-    json.dump(cur, fh, indent=2); fh.write('\n')
-PYEOF
-            ;;
-    esac
+    bash "$SCRIPT_DIR/_ensure-sinapsis-hooks.sh" "$template" "$CLAUDE_HOME/settings.json"
 }
 
 phase_sinapsis_engine() {

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -292,6 +292,19 @@ if [ -f "$REPO_ROOT/scripts/skills.sh" ]; then
     bash "$REPO_ROOT/scripts/skills.sh" sync || true
 fi
 
+# ── Re-cablear hooks de Sinapsis (idempotente) ──
+# Clave: /actualiza también REPARA instalaciones antiguas cuyos hooks nunca se
+# registraron (settings.json preexistente en la instalación original → el motor
+# de aprendizaje quedaba inerte). Preserva permisos/config/hooks del operador.
+if [ -d "$HOME/.claude/skills" ] && [ -f "$REPO_ROOT/scripts/_ensure-sinapsis-hooks.sh" ]; then
+    echo -e "${BLUE}[+]${NC} Verificando hooks de Sinapsis en ~/.claude/settings.json..."
+    if bash "$REPO_ROOT/scripts/_ensure-sinapsis-hooks.sh" >/dev/null 2>&1; then
+        echo -e "${GREEN}  OK${NC} Hooks de Sinapsis cableados/confirmados (activos al reiniciar Claude Code)"
+    else
+        echo -e "${YELLOW}  !${NC} No se pudieron verificar los hooks · si algo falla, di 'instala esto'"
+    fi
+fi
+
 # ── Done ──
 echo
 echo -e "${GREEN}${BOLD}============================================================${NC}"


### PR DESCRIPTION
Complemento de #12. Cierra el hueco de que `/actualiza` (update.sh) no llevaba el fix de hooks a los miembros ya instalados.

## Qué cambia
- Extrae el deep-merge idempotente de hooks a **`scripts/_ensure-sinapsis-hooks.sh`** (autocontenido: detección de runtime JSON + rutas MSYS), compartido por `install.sh` (ahora delega, se elimina el duplicado inline) y `update.sh`.
- **`update.sh` cablea los hooks al final** → los miembros cuyo motor de aprendizaje quedó inerte (settings.json preexistente en la instalación original) se **arreglan diciendo solo "actualiza"**, sin reinstalar.
- Idempotente; preserva permisos/config/otros hooks del operador.

## Verificación
- Sintaxis OK en los 3 scripts.
- `_ensure-sinapsis-hooks.sh` probado con settings.json "motor muerto" (hooks de otra cosa): cablea los 3 activadores, preserva el hook ajeno y los permisos, idempotente.
- `install.sh` e2e re-corrido tras el refactor (escenario miembro): `sinapsis-engine: done`, `errors[]` vacío, hooks cableados, `model` preservado → la delegación funciona.
- 5 checks del CI del repo en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)