### PR TITLE
fix(ci): el check de profundidad ignoraba los backups de update.sh

### DIFF
--- a/scripts/ci/check-skills-depth.sh
+++ b/scripts/ci/check-skills-depth.sh
@@ -14,8 +14,15 @@ import sys
 errors, warnings = [], []
 
 # 1) Destinos indexados por Claude Code: todo .claude/skills del repo (raíz y clientes)
+# Se excluyen las copias que no son instalaciones vivas: el backup con fecha que
+# crea update.sh (guarda la estructura ANTIGUA, anidada, a propósito), vendor/ y
+# cualquier archivado. Sin esto, /doctor y este check dan 🔴 falsos tras cada
+# /actualiza, apuntando a un backup que debe quedarse tal cual.
+SKIP = ("vendor", ".backup", "_archivado", "node_modules", ".git")
 for root in sorted(Path(".").glob("**/.claude/skills")):
-    if "vendor" in root.parts:
+    if any(part in SKIP or part.startswith(".backup") for part in root.parts):
+        continue
+    if any("_archived" in part for part in root.parts):
         continue
     for path in sorted(root.rglob("SKILL.md")):
         rel = path.relative_to(root)


### PR DESCRIPTION
Detectado al verificar el fix de #18 contra una instalación real.

`scripts/ci/check-skills-depth.sh` recorría **todos** los `**/.claude/skills` del árbol, incluido el `.backup/<fecha>/` que `update.sh` crea antes de aplicar un update. Ese backup guarda **a propósito** la estructura antigua anidada, así que justo después de cualquier `/actualiza` el check daba 🔴 contra una copia que debe quedarse intacta — y `/doctor` habría mostrado esos errores falsos a todo miembro que actualizara.

Ahora se excluyen los roots `.backup*/`, `vendor/`, `_archivado/`, `node_modules/` y `.git/`.

Verificado por código de salida:

| Caso | exit |
|---|---|
| Árbol limpio | 0 |
| Con un `.backup/` anidado presente | 0 |
| Con una skill anidada real en `.claude/skills/` | 1 |

CI local 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)