### PR TITLE
fix(ci): el escáner de secretos crasheaba con archivos movidos sin commitear

### DIFF
--- a/scripts/ci/check-secrets.sh
+++ b/scripts/ci/check-secrets.sh
@@ -36,6 +36,12 @@ for name in tracked:
         text = path.read_text(encoding="utf-8")
     except UnicodeDecodeError:
         continue
+    except (FileNotFoundError, IsADirectoryError, PermissionError):
+        # Trackeado en git pero ausente en disco: el operador lo movió o borró sin
+        # commitear todavía (p. ej. tras la migración de estructura de v0.11.0).
+        # No hay nada que escanear y crashear aquí dejaba un traceback de Python
+        # en la cara de cualquiera que corriese el check tras actualizar.
+        continue
     for line_no, line in enumerate(text.splitlines(), start=1):
         lower = line.lower()
         if "tu-api-key" in lower or "your-api-key" in lower or "placeholder" in lower:


### PR DESCRIPTION
Detectado ejecutando los checks en una instalación real justo después de la migración de #18.

`check-secrets.sh` lee todas las rutas de `git ls-files` y solo protegía contra `UnicodeDecodeError`. Cualquier archivo presente en el índice pero ausente en disco provocaba un **traceback de Python en crudo**. Ese es precisamente el estado que deja la migración de estructura de v0.11.0 antes de que el operador commitee: las rutas anidadas siguen en el índice mientras las carpetas ya se movieron.

Resultado: quien corriera los checks (o `/doctor`) justo después de actualizar veía un traceback en vez de un resultado.

Ahora se saltan las rutas ausentes, los directorios y las no legibles.

| Caso | exit | traceback |
|---|---|---|
| Archivo trackeado ausente en disco | 0 | no |
| Token `ghp_` real | 1 | no |

CI local 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)