### PR TITLE
fix: ronda de auditoría tras la v0.11.0 (cierra #16)

### DIFF
--- a/.claude/commands/skills.md
+++ b/.claude/commands/skills.md
@@ -37,3 +37,16 @@ Cuando el usuario pida algo que una skill de la **biblioteca** resuelve y no la 
 ## Disparadores en lenguaje natural
 
 "qué skills hay", "qué skills tengo", "lista de skills", "catálogo de skills", "instala <nombre>", "instálame la skill de <tema>", "quita/desinstala <nombre>", "qué más sabe hacer el OS".
+
+## Retirar una skill CORE
+
+Las core no se desinstalan con `remove` (el OS las necesita). Si quieres que una
+deje de cargarse —para no gastar contexto por sesión— muévela a
+`.claude/skills/_archived/<nombre>/` con el nombre exacto:
+
+```bash
+mv .claude/skills/<nombre> .claude/skills/_archived/<nombre>
+```
+
+`/actualiza` respeta ese archivado y no la reinstala. Nada se borra: para
+recuperarla, muévela de vuelta y reinicia Claude Code.

--- a/.claude/skills/marketing-brand-voice/SKILL.md
+++ b/.claude/skills/marketing-brand-voice/SKILL.md
@@ -534,7 +534,7 @@ Plus assets en `brand-context/assets/` (si Firecrawl extrajo).
 
 ## Examples
 
-Ver `references/examples.md` para 3 casos:
+Tres casos de referencia:
 1. Operador con LinkedIn pro + blog → voice profile robusto con ruta artefactos + 3 registers diferenciados
 2. Operador sin presencia online → ruta simulación 100%, voice profile auténtico
 3. Operador mixto (LinkedIn sí, Instagram no) → ruta híbrida, registro A con artefactos + registro C con simulación

--- a/.claude/skills/marketing-icp/SKILL.md
+++ b/.claude/skills/marketing-icp/SKILL.md
@@ -195,6 +195,6 @@ Ninguna. Es introspectiva + análisis de datos del operador.
 
 ## Examples
 
-Ver `references/examples.md` para 2 ICPs completos:
+Dos ICPs de referencia:
 1. Operador IA freelance servicio a gestorías españolas
 2. Agencia marketing especializada en formadores online

--- a/.claude/skills/marketing-positioning/SKILL.md
+++ b/.claude/skills/marketing-positioning/SKILL.md
@@ -181,6 +181,3 @@ Si el operador no decide: ofrecer hacer un mini test (escribir 1 LinkedIn post e
 - **Operador es tech bueno pero comm malo**: el positioning correcto puede ser "white-label tech para agencias", no servir a clientes finales.
 - **Operador es solo bueno en una vertical**: positioning vertical-first ("Operador IA para clínicas dentales") es legítimo y suele convertir mejor que horizontal.
 
-## Examples
-
-Ver `references/examples.md` para 3 casos completos.

--- a/.claude/skills/tool-output-verifier/SKILL.md
+++ b/.claude/skills/tool-output-verifier/SKILL.md
@@ -164,11 +164,7 @@ La skill caller decide:
 - **Texto multi-idioma**: validar cada idioma por separado, dar score promedio.
 - **Threshold conflicting con purpose**: ej. email "personal a un amigo" no requiere humanizer 8. Pedir al usuario que confirme purpose si humanizer falla por threshold.
 
-## Examples
-
-Ver `references/examples.md` para casos completos.
 
 ## Knowledge
 
 - `references/platform-limits.md` — tabla mantenida de límites por plataforma
-- `references/examples.md` — casos pase / fallo / borderline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,28 @@ Formato basado en [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.11.1] — 2026-08-19
+
+Ronda de auditoría tras la v0.11.0: se revisaron los scripts, las skills, la documentación y los issues/PRs abiertos. Todo lo de aquí son fallos reales encontrados y verificados, no limpieza cosmética.
+
+### Fixed
+- **Las skills que el operador archiva reaparecían en cada `/actualiza`** ([#16](https://github.com/iamasters-academy/iamasters-os/issues/16), reportado por un miembro el 21-jul). Quien retira una skill core de `.claude/skills/` (para no gastar contexto por sesión) la veía volver en cada actualización y tenía que quitarla otra vez a mano. La causa **no** era `skills.sh sync` como suponía el reporte —ese salta las core a propósito— sino el `git checkout origin/<branch> -- <archivo>` de `update.sh`: al no existir la ruta en local, la clasificaba como "skill nueva" y la restauraba. Ahora `update.sh` comprueba si la skill está en `.claude/skills/_archived/<nombre>/` y respeta la decisión del operador, informando de cuáles ha respetado. Verificado en sandbox: las archivadas no vuelven y el resto se actualiza con normalidad.
+- **`/doctor` daba errores rojos falsos justo después de actualizar** ([#19](https://github.com/iamasters-academy/iamasters-os/pull/19)). El check de profundidad recorría también el `.backup/<fecha>/` que crea `update.sh`, que guarda **a propósito** la estructura antigua anidada. Se excluyen los roots `.backup*/`, `vendor/`, `_archivado/`, `node_modules/` y `.git/`.
+- **El escáner de secretos crasheaba con un traceback de Python** ([#20](https://github.com/iamasters-academy/iamasters-os/pull/20)). Leía todas las rutas de `git ls-files` sin tolerar que un archivo esté en el índice pero ya no en disco — exactamente el estado que deja la migración de estructura antes de commitear.
+- **Seis skills remitían a un `references/examples.md` que nunca se creó**: `marketing-icp`, `marketing-positioning`, `marketing-brand-voice` y `tool-output-verifier` (core), `marketing-copywriting` y `marketing-content-repurposing` (biblioteca). Claude seguía la instrucción, intentaba leer el archivo y fallaba en silencio. Donde los casos ya estaban enumerados en el propio `SKILL.md` se conservan; donde la sección quedaba vacía se retira. Los ejemplos de ICP, posicionamiento y voz salen del criterio del operador: no se inventan aquí.
+- **Una skill de la biblioteca invocaba una skill personal del autor que no existe en el repo**: `tool-web-legal-audit` hacía "invoca la skill `whatsapp`" con el `.docx` de la auditoría. Ningún miembro tiene esa skill. Ahora entrega la ruta y ofrece usar la skill de envío que el operador tenga, sin asumirla.
+- **`marketing-content-repurposing` citaba `strategy-trending-research`** como si existiera; esa skill nunca se creó (aparece como "futura" en la presentación de equipo). Reformulado sin la dependencia fantasma.
+- **`docs/multi-client-guide.md` mandaba ejecutar `bash scripts/sync-synapsis.sh`** ("futura skill v0.5") — script que no existe, y con "Sinapsis" mal escrito. Reescrito el troubleshooting con el comportamiento real: las skills se cargan desde el directorio de arranque hacia arriba, las de un subdirectorio (`clients/<nombre>/`) no entran hasta que Claude toca un archivo de ahí, y toda skill debe estar a un nivel.
+- **Precedencia de `find` en `scripts/install.sh`**: `-type f -name "_*.json" -o -name "_*.sh"` no aplicaba `-type f` al segundo patrón, así que un directorio llamado `_algo.sh` entraba en el checksum de integridad de Sinapsis y podía provocar un falso positivo de drift. Agrupado con paréntesis.
+
+### Added
+- **`skill_archived_by_operator()`** en `scripts/update.sh`: para retirar una skill core, mueve su carpeta a `.claude/skills/_archived/<nombre>/` con el nombre exacto. Las copias que archiva `_flatten-skills.sh` llevan sufijo `-anidada-<fecha>` y no cuentan como decisión del operador, así que no interfieren.
+
+### Notas
+- Los arreglos de `update.sh` viajan dentro de `update.sh`, que se sobrescribe a sí mismo durante `/actualiza`: **empiezan a aplicar a partir de la actualización siguiente**. Si vienes de ≤ v0.10.2 y tenías skills archivadas, en la primera pasada pueden volver una vez; vuelve a archivarlas y no reaparecerán más.
+
+---
+
 ## [0.11.0] — 2026-08-18
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,7 +36,7 @@ keywords:
   - iamasters-academy
 license: MIT
 license-url: "https://github.com/iamasters-academy/iamasters-os/blob/main/LICENSE"
-version: "0.11.0"
+version: "0.11.1"
 date-released: "2026-06-11"
 preferred-citation:
   type: software

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/iamasters-academy/iamasters-os/releases"><img src="https://img.shields.io/badge/version-v0.11.0-orange.svg" alt="Version"></a>
+  <a href="https://github.com/iamasters-academy/iamasters-os/releases"><img src="https://img.shields.io/badge/version-v0.11.1-orange.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="vendor/sinapsis/"><img src="https://img.shields.io/badge/engine-Sinapsis%20v4.6.1-purple.svg" alt="Powered by Sinapsis"></a>
   <a href="https://angelaparicio.com"><img src="https://img.shields.io/badge/maintained%20by-Angel%20Aparicio-ff8c42.svg" alt="Maintained by Angel Aparicio"></a>

--- a/docs/multi-client-guide.md
+++ b/docs/multi-client-guide.md
@@ -183,9 +183,10 @@ cd clients/biggest-client && claude
 - Comprueba `clients/<nombre>/CLAUDE.md` referencia el path correcto
 
 ### "Skills del raíz no aparecen al estar en cliente"
-- Las skills del raíz (`.claude/skills/`) son globales en el repo, deberían estar disponibles
-- Si no se invocan: reinicia Claude Code (Ctrl+C × 2)
-- Si persiste: ejecuta `bash scripts/sync-synapsis.sh` (futura skill v0.5)
+- Las skills del raíz (`.claude/skills/`) se cargan desde el directorio donde arrancas Claude Code y en cada directorio padre hasta la raíz del repo. Si arrancas en `clients/<nombre>/`, las del raíz también entran.
+- Al revés NO es automático: si arrancas en la raíz, las skills de `clients/<nombre>/.claude/skills/` no se cargan hasta que Claude lee o edita un archivo dentro de esa carpeta. Hasta entonces no salen en el autocompletado.
+- Comprueba que cada skill está a UN nivel: `.claude/skills/<nombre>/SKILL.md`. Una carpeta de categoría intermedia la hace invisible (`Unknown skill`). Verifícalo con `bash scripts/ci/check-skills-depth.sh` o con `/doctor`.
+- Tras mover o instalar skills, reinicia Claude Code (Ctrl+C × 2): el índice se construye al arrancar la sesión.
 
 ### "Mezclo info de clientes accidentalmente"
 - Es señal de no respetar `cd clients/X` antes de trabajar

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -614,9 +614,9 @@ compute_and_store_checksum() {
     # Hash de los archivos clave de Sinapsis para detectar drift posterior
     local files_hash
     if command -v shasum >/dev/null 2>&1; then
-        files_hash=$(find "$SKILLS_DIR" -maxdepth 1 -type f -name "_*.json" -o -name "_*.sh" 2>/dev/null | sort | xargs shasum -a 256 2>/dev/null | shasum -a 256 | awk '{print $1}')
+        files_hash=$(find "$SKILLS_DIR" -maxdepth 1 -type f \( -name "_*.json" -o -name "_*.sh" \) 2>/dev/null | sort | xargs shasum -a 256 2>/dev/null | shasum -a 256 | awk '{print $1}')
     elif command -v sha256sum >/dev/null 2>&1; then
-        files_hash=$(find "$SKILLS_DIR" -maxdepth 1 -type f -name "_*.json" -o -name "_*.sh" 2>/dev/null | sort | xargs sha256sum 2>/dev/null | sha256sum | awk '{print $1}')
+        files_hash=$(find "$SKILLS_DIR" -maxdepth 1 -type f \( -name "_*.json" -o -name "_*.sh" \) 2>/dev/null | sort | xargs sha256sum 2>/dev/null | sha256sum | awk '{print $1}')
     else
         files_hash="sha-tool-not-found"
     fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -156,6 +156,20 @@ fi
 
 echo -e "${CYAN}  ->${NC} Hay cambios upstream. Analizando..."
 
+# ¿El operador retiró esta skill a propósito? (issue #16)
+# Retirar = mover la carpeta a .claude/skills/_archived/<nombre>/ con el nombre
+# EXACTO. Se exige exacto para no confundirla con las copias que archiva
+# _flatten-skills.sh, que llevan sufijo "-anidada-<fecha>".
+skill_archived_by_operator() {
+    local rest name
+    case "$1" in .claude/skills/*) ;; *) return 1 ;; esac
+    rest="${1#.claude/skills/}"
+    name="${rest%%/*}"
+    [ -n "$name" ] || return 1
+    case "$name" in _archived) return 1 ;; esac
+    [ -d "$REPO_ROOT/.claude/skills/_archived/$name" ]
+}
+
 # ── Step 5: Categorize changes ──
 echo -e "${BLUE}[5/6]${NC} Clasificando cambios..."
 
@@ -222,8 +236,15 @@ echo -e "${BLUE}[6/6]${NC} Aplicando updates..."
 # Apply safe updates (sin pisar archivos con cambios locales sin commitear)
 PENDING_CONFLICTS=()
 UPDATED=0
+RESPECTED_ARCHIVED=()
 for file in "${SAFE_TO_UPDATE[@]}" "${SKILLS_NEW[@]}"; do
     [ -z "$file" ] && continue
+    if skill_archived_by_operator "$file"; then
+        # El operador la archivó para no cargarla (contexto por sesión). Antes se
+        # restauraba en cada /actualiza y había que volver a quitarla a mano.
+        RESPECTED_ARCHIVED+=("$file")
+        continue
+    fi
     if is_locally_modified "$file"; then
         PENDING_CONFLICTS+=("$file")
         continue
@@ -231,6 +252,11 @@ for file in "${SAFE_TO_UPDATE[@]}" "${SKILLS_NEW[@]}"; do
     git checkout "origin/$CURRENT_BRANCH" -- "$file" 2>/dev/null || true
     UPDATED=$((UPDATED+1))
 done
+
+if [ ${#RESPECTED_ARCHIVED[@]} -gt 0 ]; then
+    ARCHIVED_NAMES=$(printf '%s\n' "${RESPECTED_ARCHIVED[@]}" | sed 's|^.claude/skills/||; s|/.*||' | sort -u | tr '\n' ' ')
+    echo -e "  ${DIM}·${NC} Respetadas como archivadas (no se reinstalan): ${ARCHIVED_NAMES}"
+fi
 
 if [ "$UPDATED" -gt 0 ]; then
     echo -e "${GREEN}  OK${NC} $UPDATED archivos actualizados (safe + new skills)"

--- a/skills-library/marketing/marketing-content-repurposing/SKILL.md
+++ b/skills-library/marketing/marketing-content-repurposing/SKILL.md
@@ -9,7 +9,7 @@ description: Convierte una pieza fuente (video YouTube, podcast, transcript reun
 
 - Usuario dice: "repurpose este video", "saca contenido de este podcast", "del último Café Camaleónico, sácame X piezas"
 - Tras una clase / talk / video largo, automatizar la distribución
-- Skill `strategy-trending-research` la sugiere cuando detecta un tema valioso del operador para amplificar
+- Cuando el operador detecta un tema propio que merece amplificarse
 
 ## Process
 
@@ -156,6 +156,6 @@ Paquete completo en `projects/marketing-content-repurposing/<fecha>-<slug>/` con
 
 ## Examples
 
-Ver `references/examples.md` para 2 casos:
+Dos casos de referencia:
 1. Repurpose video YouTube de 25 min sobre Claude Code → 8 piezas
 2. Repurpose transcript reunión cliente sobre case study → 5 piezas con sanitización

--- a/skills-library/marketing/marketing-copywriting/SKILL.md
+++ b/skills-library/marketing/marketing-copywriting/SKILL.md
@@ -191,6 +191,3 @@ Aplicar y volver a verificar (Paso 5).
 - **Tema sensible** (política, religión, etc.): generar pero advertir que las plataformas pueden afectar visibilidad.
 - **Output requerido en idioma distinto al voice-profile**: marcar low-confidence; recomendar revisar manualmente.
 
-## Examples
-
-Ver `references/examples.md` para casos LinkedIn, X thread, email, landing hero.

--- a/skills-library/tools/tool-web-legal-audit/references/workflow.md
+++ b/skills-library/tools/tool-web-legal-audit/references/workflow.md
@@ -165,7 +165,7 @@ Crea `remediation.md` con:
 open <output-dir>/Auditoria-Legal-*.docx
 ```
 
-Pregunta al usuario si quiere enviarlo por WhatsApp. Si sí, invoca la skill `whatsapp` con la ruta del docx.
+Entrega la ruta del `.docx` al usuario. Si tiene instalada alguna skill de envío (WhatsApp, email), ofrécele usarla; no asumas que existe.
 
 ## Errores comunes y cómo evitarlos
 


### PR DESCRIPTION
Cierra #16.

Revisión completa de scripts, skills, documentación e issues/PRs abiertos. **Todo lo que hay aquí son fallos reales verificados**, no limpieza cosmética.

## Lo que estaba roto

| Qué | Impacto |
|---|---|
| **#16** · las skills archivadas por el operador reaparecían en cada `/actualiza` | había que volver a quitarlas a mano tras cada actualización |
| **6 skills** remitían a un `references/examples.md` que nunca se creó | Claude seguía la instrucción y fallaba en silencio |
| `tool-web-legal-audit` invocaba la skill **personal del autor** `whatsapp` | ningún miembro la tiene |
| `marketing-content-repurposing` citaba `strategy-trending-research` | skill que nunca existió |
| `multi-client-guide` mandaba ejecutar `scripts/sync-synapsis.sh` | script inexistente, y "Sinapsis" mal escrito |
| precedencia de `find` en `install.sh` | un directorio `_algo.sh` entraba en el checksum de integridad → falso drift |

### Sobre el #16

La causa que suponía el reporte (`skills.sh sync`) **no era correcta**: `sync` salta las core a propósito (`# core: la actualiza git, no nosotros`). El culpable era el `git checkout origin/<branch> -- <archivo>` de `update.sh`: al no encontrar la ruta en local la clasificaba como "skill nueva" y la restauraba.

`update.sh` ahora comprueba `.claude/skills/_archived/<nombre>/` y respeta la decisión del operador, informando de cuáles ha respetado. Se exige el nombre **exacto** para no confundirlo con las copias que archiva `_flatten-skills.sh` (llevan sufijo `-anidada-<fecha>`).

Verificado en sandbox: las archivadas no vuelven, el resto se actualiza con normalidad, `health-check` sigue presente.

Documentado en `/skills`: para retirar una core, `mv .claude/skills/<nombre> .claude/skills/_archived/<nombre>`.

### Sobre las seis skills sin ejemplos

Donde los casos ya estaban enumerados en el propio `SKILL.md` se conservan y solo se quita la promesa del archivo. Donde la sección `## Examples` quedaba vacía, se retira. **Los ejemplos de ICP, posicionamiento y voz de marca son material del operador y no se inventan en un PR.**

## Lo que NO he tocado, a propósito

`/system-status` aparece en `docs/installation.md` y mi auditoría lo marcó como inexistente, pero `vendor/sinapsis/commands/` lo trae y el instalador de Sinapsis lo copia a `~/.claude/commands/`. Funciona: falso positivo.

## Verificación

- CI local 6/6.
- Fix del #16 probado en sandbox con el escenario real (operador en la versión nueva que archiva dos skills core y actualiza).
- Bug de precedencia de `find` demostrado con un caso reproducible antes/después.

**Nota**: los arreglos de `update.sh` viajan dentro de `update.sh`, que se sobrescribe durante `/actualiza`, así que aplican a partir de la actualización siguiente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)