### PR TITLE
fix(update): /actualiza converge en vez de re-reportar su propio trabajo (v0.11.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ yarn.lock
 
 # Personalizaciones del operador sobre skills curadas — sobreviven updates
 **/SKILL.local.md
+
+# Commit upstream ya aplicado por scripts/update.sh (estado local)
+.claude/.upstream-state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ Formato basado en [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.11.2] — 2026-08-19
+
+### Fixed
+- **`/actualiza` reportaba como conflicto tuyo lo que él mismo acababa de traer.** `update.sh` no hace merge ni mueve `HEAD` —trae archivos con `git checkout origin/<rama> -- <archivo>` para no pisar nunca los datos del operador—, pero medía **todo** contra `HEAD`, que se queda atrás para siempre. Consecuencia: un archivo traído por una actualización previa parecía "editado por el operador" en cada actualización siguiente. Medido en sandbox: **33 conflictos falsos en una segunda pasada seguida, con el árbol perfectamente al día**, y un `git status` permanentemente sucio. Fue lo que hizo sospechar a `/doctor` de "archivos staged sin commit" al diagnosticar [#17](https://github.com/iamasters-academy/iamasters-os/issues/17), y la raíz que compartía con [#16](https://github.com/iamasters-academy/iamasters-os/issues/16). Ahora `update.sh` registra en `.claude/.upstream-state` (local, gitignored) qué commit upstream aplicó y mide contra **esa base**: si un archivo coincide con la versión ya aplicada, lo trajo el update anterior y no es una edición tuya. Una segunda pasada seguida responde **"Ya estás al día"**.
+- **Los archivos que upstream retira nunca desaparecían de tu repo.** `git checkout origin/<rama> -- <ruta>` falla en silencio para una ruta que ya no existe en remoto (el `|| true` se lo comía), así que cada archivo renombrado o retirado upstream se quedaba para siempre. Ahora se retiran con tres salvaguardas: **nunca** datos del operador (`brand-context/`, `context/`, `projects/`, `clients/`, `.env`, `loops/`, `settings.json`), **nunca** si tú habías editado el archivo (se mantiene y se avisa), y **copia al backup** antes de tocar nada. `.claude/skills/` se excluye a propósito: de ese árbol se encarga `_flatten-skills.sh`, que además rescata los `SKILL.local.md`.
+- **`rollback.sh` invalida el estado de upstream.** Volver atrás deja el árbol en un punto anterior, así que el commit registrado como aplicado ya no describe lo que hay en disco; el siguiente `/actualiza` vuelve a medir contra `HEAD` en vez de fiarse de una base falsa.
+
+### Notas
+- Verificado con 8 escenarios en sandbox: convergencia en dos pasadas, edición real del operador preservada y reportada, datos del operador intocables, primer update sin estado (retrocompatible), retirada de archivos obsoletos con copia en backup, retirada bloqueada cuando el operador editó el archivo, camino completo de migración desde v0.10.2 (0 → 17 skills, 6/6 checks) y rollback.
+- Si vienes de **≤ v0.10.2**: el ruido de conflictos aparece una última vez (tu `update.sh` en disco es el antiguo y no registra la base todavía) y a partir de la actualización siguiente queda limpio.
+
+---
+
 ## [0.11.1] — 2026-08-19
 
 Ronda de auditoría tras la v0.11.0: se revisaron los scripts, las skills, la documentación y los issues/PRs abiertos. Todo lo de aquí son fallos reales encontrados y verificados, no limpieza cosmética.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,7 +36,7 @@ keywords:
   - iamasters-academy
 license: MIT
 license-url: "https://github.com/iamasters-academy/iamasters-os/blob/main/LICENSE"
-version: "0.11.1"
+version: "0.11.2"
 date-released: "2026-06-11"
 preferred-citation:
   type: software

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/iamasters-academy/iamasters-os/releases"><img src="https://img.shields.io/badge/version-v0.11.1-orange.svg" alt="Version"></a>
+  <a href="https://github.com/iamasters-academy/iamasters-os/releases"><img src="https://img.shields.io/badge/version-v0.11.2-orange.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="vendor/sinapsis/"><img src="https://img.shields.io/badge/engine-Sinapsis%20v4.6.1-purple.svg" alt="Powered by Sinapsis"></a>
   <a href="https://angelaparicio.com"><img src="https://img.shields.io/badge/maintained%20by-Angel%20Aparicio-ff8c42.svg" alt="Maintained by Angel Aparicio"></a>

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -172,6 +172,15 @@ for d in "${USER_DATA_PATHS[@]}"; do
 done
 echo -e "${GREEN}  OK${NC} $RESTORED rutas restauradas desde el backup"
 
+# El rollback deja el árbol en un estado anterior, así que el commit upstream que
+# update.sh tenía registrado como aplicado ya no describe lo que hay en disco.
+# Se invalida: el siguiente /actualiza vuelve a medir contra HEAD (comportamiento
+# de un primer update) en vez de fiarse de una base que ya no es cierta.
+if [ -f "$REPO_ROOT/.claude/.upstream-state" ]; then
+    rm -f "$REPO_ROOT/.claude/.upstream-state"
+    echo -e "${GREEN}  OK${NC} Estado de upstream invalidado (lo recalcula el próximo /actualiza)"
+fi
+
 echo ""
 echo -e "${GREEN}${BOLD}============================================================${NC}"
 echo -e "${GREEN}${BOLD}  Rollback completado${NC}"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -73,9 +73,39 @@ if [ -n "$LOCALLY_MODIFIED" ]; then
     fi
 fi
 
+# ── Base upstream ya aplicada ────────────────────────────────────────────────
+# update.sh no hace merge ni mueve HEAD: trae archivos con `git checkout
+# origin/<rama> -- <archivo>` para no pisar nunca los datos del operador. El
+# efecto secundario era que TODO se medía contra HEAD, que se queda atrás para
+# siempre: un archivo traído por el update anterior parecía "editado por el
+# operador" en cada actualización siguiente, y el informe se llenaba de
+# conflictos falsos (33 en una segunda pasada seguida, con el árbol al día).
+# Guardamos qué commit upstream se aplicó y medimos contra ÉL.
+UPSTREAM_STATE="$REPO_ROOT/.claude/.upstream-state"
+APPLIED_COMMIT=""
+if [ -f "$UPSTREAM_STATE" ]; then
+    APPLIED_COMMIT=$(head -1 "$UPSTREAM_STATE" 2>/dev/null | tr -d '[:space:]')
+    # si el commit ya no existe (rebase, clon nuevo, historial reescrito), se ignora
+    git cat-file -e "${APPLIED_COMMIT}^{commit}" 2>/dev/null || APPLIED_COMMIT=""
+fi
+BASE_REF="${APPLIED_COMMIT:-HEAD}"
+
 is_locally_modified() {
-    # $1 = ruta relativa; 0 si el archivo tiene cambios locales sin commitear
-    [ -n "$LOCALLY_MODIFIED" ] && echo "$LOCALLY_MODIFIED" | grep -qxF "$1"
+    # 0 = el OPERADOR tocó este archivo (hay que preservarlo y preguntar)
+    local f="$1"
+    if [ -n "$APPLIED_COMMIT" ]; then
+        if git cat-file -e "$APPLIED_COMMIT:$f" 2>/dev/null; then
+            # coincide con la versión upstream ya aplicada -> lo trajo el update
+            # anterior, no es una edición del operador
+            git diff --quiet "$APPLIED_COMMIT" -- "$f" 2>/dev/null && return 1
+            return 0
+        fi
+        # no existía en la base upstream: si está en disco, lo creó el operador
+        [ -e "$REPO_ROOT/$f" ] && return 0
+        return 1
+    fi
+    # primer update sin estado: comportamiento anterior
+    [ -n "$LOCALLY_MODIFIED" ] && echo "$LOCALLY_MODIFIED" | grep -qxF "$f"
 }
 
 CURRENT_BRANCH=$(git branch --show-current)
@@ -147,7 +177,8 @@ if [ -z "$REMOTE" ]; then
     exit 0
 fi
 
-if [ "$LOCAL" = "$REMOTE" ]; then
+BASE_SHA=$(git rev-parse "$BASE_REF" 2>/dev/null || echo "$LOCAL")
+if [ "$BASE_SHA" = "$REMOTE" ] || [ "$LOCAL" = "$REMOTE" ]; then
     echo -e "${GREEN}  OK${NC} Ya estás al día. Nada nuevo upstream."
     echo
     echo "Update completado (sin cambios)."
@@ -173,7 +204,9 @@ skill_archived_by_operator() {
 # ── Step 5: Categorize changes ──
 echo -e "${BLUE}[5/6]${NC} Clasificando cambios..."
 
-CHANGED_FILES=$(git diff --name-only HEAD..origin/"$CURRENT_BRANCH")
+CHANGED_FILES=$(git diff --name-only "$BASE_REF"..origin/"$CURRENT_BRANCH")
+# rutas que existían en la base y upstream ya no tiene (renombradas o retiradas)
+DELETED_UPSTREAM=$(git diff --name-only --diff-filter=D "$BASE_REF"..origin/"$CURRENT_BRANCH")
 
 # Categorize
 SAFE_TO_UPDATE=()
@@ -322,6 +355,46 @@ if [ ${#PENDING_CONFLICTS[@]} -gt 0 ]; then
     echo -e "  O dile a Claude: ${CYAN}\"aplica la versión nueva de <archivo>\"${NC}"
 fi
 
+# ── Rutas que upstream ya no tiene ───────────────────────────────────────────
+# `git checkout origin/<rama> -- <ruta>` falla en silencio para una ruta que ya no
+# existe en remoto (el `|| true` se lo come), así que un archivo retirado o
+# renombrado upstream se quedaba en el repo del operador para siempre.
+# Se retiran con tres salvaguardas: nunca datos del operador, nunca si el
+# operador editó el archivo, y copia al backup antes de tocarlo.
+# `.claude/skills/` se excluye a propósito: de ese árbol se encarga
+# _flatten-skills.sh, que además rescata los SKILL.local.md antes de archivar.
+RETIRED=0
+RETIRED_KEPT=()
+if [ -n "${DELETED_UPSTREAM:-}" ] && [ -n "$APPLIED_COMMIT" ]; then
+    while IFS= read -r gone; do
+        [ -n "$gone" ] || continue
+        [ -e "$REPO_ROOT/$gone" ] || continue
+        case "$gone" in
+            brand-context/*|context/*|projects/*|clients/*|.env|.env.*) continue ;;
+            .claude/skills/*) continue ;;
+            .claude/settings.json|loops/*) continue ;;
+        esac
+        # ¿lo editó el operador? entonces no se toca
+        if ! git diff --quiet "$APPLIED_COMMIT" -- "$gone" 2>/dev/null; then
+            RETIRED_KEPT+=("$gone")
+            continue
+        fi
+        mkdir -p "$BACKUP_DIR/$(dirname "$gone")"
+        cp -R "$REPO_ROOT/$gone" "$BACKUP_DIR/$gone" 2>/dev/null || true
+        rm -rf "$REPO_ROOT/$gone"
+        RETIRED=$((RETIRED+1))
+    done <<EOF
+$DELETED_UPSTREAM
+EOF
+fi
+if [ "$RETIRED" -gt 0 ]; then
+    echo -e "  ${DIM}·${NC} $RETIRED archivo(s) retirados por upstream (copia en el backup)"
+fi
+if [ ${#RETIRED_KEPT[@]} -gt 0 ]; then
+    echo -e "  ${YELLOW}!${NC} Upstream retiró ${#RETIRED_KEPT[@]} archivo(s) que TÚ habías editado · se mantienen:"
+    for f in "${RETIRED_KEPT[@]}"; do echo -e "    ${YELLOW}·${NC} $f"; done
+fi
+
 # ── Migración de estructura: aplanar skills anidadas (v0.11.0) ──
 # Se invoca como script APARTE a propósito: update.sh se sobrescribe a sí mismo
 # durante este update y bash seguiría ejecutando la versión antigua ya cargada,
@@ -351,6 +424,12 @@ if [ -d "$HOME/.claude/skills" ] && [ -f "$REPO_ROOT/scripts/_ensure-sinapsis-ho
         echo -e "${YELLOW}  !${NC} No se pudieron verificar los hooks · si algo falla, di 'instala esto'"
     fi
 fi
+
+# ── Registrar qué commit upstream se ha aplicado ─────────────────────────────
+# Sin esto, el próximo /actualiza volvería a medir contra HEAD (que no se mueve)
+# y reportaría como conflicto todo lo que acaba de traer.
+mkdir -p "$REPO_ROOT/.claude"
+printf '%s\n' "$REMOTE" > "$UPSTREAM_STATE"
 
 # ── Done ──
 echo


### PR DESCRIPTION
Raíz común que quedaba de #16 y #17.

`update.sh` evita merges a propósito y **nunca mueve `HEAD`**: trae archivos con `git checkout origin/<rama> -- <archivo>` para no pisar jamás los datos del operador. El problema es que medía **todo** contra `HEAD`, que por eso se queda atrás para siempre. Un archivo traído por una actualización previa parecía "editado por el operador" en cada actualización siguiente.

Medido en sandbox: **33 conflictos falsos en una segunda pasada seguida**, con el árbol perfectamente al día, y un `git status` permanentemente sucio. Es lo que hizo sospechar a `/doctor` de "archivos staged sin commit" mientras diagnosticábamos #17.

## Qué cambia

| | Antes | Ahora |
|---|---|---|
| 2ª pasada seguida | `Skills modificadas: 33 (potencial conflicto)` | **`Ya estás al día`** |
| Archivos que upstream retira | se quedaban para siempre | se retiran, con copia en el backup |
| Edición real del operador | indistinguible del ruido | se detecta, se preserva y se reporta |
| Tras un `rollback` | la base registrada mentía | se invalida |

- Se registra el commit upstream aplicado en `.claude/.upstream-state` (local, gitignored) y se mide contra **esa base**. Si un archivo coincide con la versión ya aplicada, lo trajo el update anterior y no es una edición del operador.
- Las rutas que upstream ha retirado se limpian con **tres salvaguardas**: nunca datos del operador (`brand-context/`, `context/`, `projects/`, `clients/`, `.env`, `loops/`, `settings.json`), nunca si el operador editó el archivo (se mantiene y se avisa), y copia al backup antes de tocar nada. **`.claude/skills/` se excluye a propósito**: de ese árbol se encarga `_flatten-skills.sh`, que además rescata los `SKILL.local.md` — retirar ahí rompería ese rescate.
- `rollback.sh` invalida el estado.

## Verificación — 8 escenarios en sandbox

| Escenario | Resultado |
|---|---|
| Dos `/actualiza` seguidos | 2º responde "Ya estás al día" |
| El operador edita una skill y upstream también | conflicto reportado, su edición intacta |
| `brand-context/` y `context/` propios | intocados |
| Primer update sin archivo de estado | funciona igual que antes (retrocompatible) |
| Upstream retira un archivo | retirado + copia en el backup |
| Upstream lo retira pero el operador lo había editado | se mantiene, con aviso |
| Camino completo desde v0.10.2 | 0 → 17 skills, 0 anidadas, `SKILL.local.md` rescatado, 6/6 checks |
| `rollback.sh` | estado invalidado |

CI local 6/6.

**Nota para quien venga de ≤ v0.10.2**: el ruido aparece una última vez (su `update.sh` en disco es el antiguo y aún no registra la base) y desde la actualización siguiente queda limpio. Verificado: update 2 → 33 modificadas, update 3 y 4 → "Ya estás al día".

🤖 Generated with [Claude Code](https://claude.com/claude-code)