### PR TITLE
fix(update): keep the operator's config files instead of overwriting them

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -214,6 +214,7 @@ USER_DATA_CONFLICT=()
 SKILLS_NEW=()
 SKILLS_MODIFIED=()
 SKILLS_OBSOLETE=()
+OPERATOR_CONFIG=()
 
 while IFS= read -r file; do
     case "$file" in
@@ -235,6 +236,14 @@ while IFS= read -r file; do
                 SKILLS_NEW+=("$file")
             fi
             ;;
+        # Archivos de configuracion que el OPERADOR personaliza. Upstream tambien
+        # los toca, asi que no son 'system files': pisarlos borra su trabajo.
+        # El 24-ago-2026 un update se llevo por delante el bloque de exclusiones
+        # del .gitignore (dejando secrets/ committeable), la tabla de routing de
+        # CLAUDE.md, los permisos de settings.json y dos secciones de documentacion.
+        .gitignore|CLAUDE.md|AGENTS.md|.env.example|.claude/settings.json)
+            OPERATOR_CONFIG+=("$file")
+            ;;
         # Sinapsis vendored: safe to update (es upstream del repo de Luis)
         vendor/sinapsis/*)
             SAFE_TO_UPDATE+=("$file")
@@ -252,6 +261,7 @@ echo -e "  ${GREEN}Safe to update${NC}: ${#SAFE_TO_UPDATE[@]} archivos (system, 
 echo -e "  ${CYAN}Skills nuevas${NC}: ${#SKILLS_NEW[@]} archivos"
 echo -e "  ${YELLOW}Skills modificadas${NC}: ${#SKILLS_MODIFIED[@]} archivos (potencial conflicto)"
 echo -e "  ${RED}User data${NC}: ${#USER_DATA_CONFLICT[@]} archivos (NUNCA se tocan, ignoramos upstream)"
+echo -e "  ${YELLOW}Config del operador${NC}: ${#OPERATOR_CONFIG[@]} archivos (keep local; los revisas tu)"
 if [ ${#SKILLS_OBSOLETE[@]} -gt 0 ]; then
     echo -e "  ${DIM}Rutas obsoletas${NC}: ${#SKILLS_OBSOLETE[@]} archivos (renombrados upstream, se archivan)"
 fi
@@ -340,6 +350,13 @@ fi
 # Skip user data (always keep local — that's the contract)
 if [ ${#USER_DATA_CONFLICT[@]} -gt 0 ]; then
     echo -e "${CYAN}  ->${NC} ${#USER_DATA_CONFLICT[@]} archivos de user data ignorados (siempre keep local)"
+fi
+
+# La config del operador (.gitignore, CLAUDE.md, settings.json…) se mantiene SIEMPRE
+# local y se reporta por el mismo canal que el resto de pendientes, para que el
+# operador decida archivo a archivo si quiere la version de upstream.
+if [ ${#OPERATOR_CONFIG[@]} -gt 0 ]; then
+    PENDING_CONFLICTS+=("${OPERATOR_CONFIG[@]}")
 fi
 
 # Report pending conflicts (modo no-interactivo: nada se pisó, todo se lista)


### PR DESCRIPTION
Cierra #23.

`update.sh` clasificaba `.gitignore`, `CLAUDE.md`, `AGENTS.md`, `.env.example` y `.claude/settings.json` como *system files* y los sustituía por la versión de upstream en cada ejecución.

La guardia que ya existe (`is_locally_modified`, `scripts/update.sh:93`) no alcanza a cubrirlos: compara contra el commit guardado en `.claude/.upstream-state`, un archivo que estrena esta misma versión, así que en el primer update no hay baseline y se cae al camino de la línea 107 — mirar solo los cambios sin commitear. Si el operador tuvo que commitear sus personalizaciones para poder hacer el `pull`, se leen como intactas y se pisan.

Estos cinco archivos son terreno compartido: upstream los evoluciona **y** el operador los personaliza. El parche les da su propia rama en el clasificador (`OPERATOR_CONFIG`): se mantiene siempre la versión local y se reportan por el canal de «Pendientes de decisión» que el script ya tiene, para aceptar la de upstream archivo a archivo. No dependen del baseline.

**Alcance**: 17 líneas, solo `scripts/update.sh`. No cambia el comportamiento de ningún otro archivo ni toca el flujo de skills.

**Probado** en una instalación real (Windows/Git Bash): los cinco archivos se clasifican como `OPERATOR_CONFIG`, sobreviven al update y salen listados en «Pendientes de decisión».
